### PR TITLE
Feature: Support All Flag for Deployment Deploy Method

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .idea/
 .DS_Store
+
+# Nix
 .direnv
+result

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 .DS_Store
+.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1758277210,
+        "narHash": "sha256-iCGWf/LTy+aY0zFu8q12lK8KuZp7yvdhStehhyX1v8w=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8eaee110344796db060382e15d3af0a9fc396e0e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -13,44 +13,16 @@
       system: let
         pkgs = import nixpkgs {inherit system;};
 
-        # go-migrate-pg = pkgs.go-migrate.overrideAttrs (oldAttrs: {
-        #   tags = ["postgres"];
-        # });
-
-        # swag = pkgs.buildGoModule rec {
-        #   pname = "swag";
-        #   version = "v2.0.0-rc4";
-
-        #   src = pkgs.fetchFromGitHub {
-        #     owner = "swaggo";
-        #     repo = "swag";
-        #     rev = version;
-        #     sha256 = "sha256-3dX01PAVEkn8ciVNbIn1IwiSkwogPJLYNo6xTg9jhDA=";
-        #   };
-
-        #   vendorHash = "sha256-bUMW9wjPIT3JLMw9F/NvWqZv1M62o/Y4gIpp6XyHbek=";
-        #   subPackages = ["cmd/swag"];
-        # };
-
         app = pkgs.buildGoModule {
-          pname = "go-app";
-          version = "0.1.0";
+          pname = "deploys-cli";
+          version = "1.1.0";
 
           src = ./.;
 
-          vendorHash = "sha256-jx70HhXLbBt63Vt0iZK8aUwoQnpe57MIjUMzXsnaRgA=";
-
-          nativeBuildInputs = [
-            # swag
-          ];
-
-          preBuild = ''
-            # Generate Swagger docs
-            # swag init -v3.1 -o docs -g main.go --parseDependency --parseInternal
-          '';
+          vendorHash = "sha256-S5nq6DK4356LCMYKX3anjcySAxZhGxFWu1qKXR44C94=";
 
           meta = with pkgs.lib; {
-            description = "Go application with Swagger documentation";
+            description = "Deploys.app CLI";
             license = licenses.mit;
           };
         };
@@ -62,16 +34,11 @@
 
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [
-            go_1_25
+            go_1_24
             gopls
             golangci-lint
 
             air
-            # swag
-
-            # sqlc
-            # go-migrate-pg
-            # sql-formatter
 
             pre-commit
           ];
@@ -79,7 +46,6 @@
           shellHook = ''
             echo "Go development environment ready"
             echo "Go version: $(go version)"
-            # echo "Swag version: $(swag --version)"
           '';
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,87 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        pkgs = import nixpkgs {inherit system;};
+
+        # go-migrate-pg = pkgs.go-migrate.overrideAttrs (oldAttrs: {
+        #   tags = ["postgres"];
+        # });
+
+        # swag = pkgs.buildGoModule rec {
+        #   pname = "swag";
+        #   version = "v2.0.0-rc4";
+
+        #   src = pkgs.fetchFromGitHub {
+        #     owner = "swaggo";
+        #     repo = "swag";
+        #     rev = version;
+        #     sha256 = "sha256-3dX01PAVEkn8ciVNbIn1IwiSkwogPJLYNo6xTg9jhDA=";
+        #   };
+
+        #   vendorHash = "sha256-bUMW9wjPIT3JLMw9F/NvWqZv1M62o/Y4gIpp6XyHbek=";
+        #   subPackages = ["cmd/swag"];
+        # };
+
+        app = pkgs.buildGoModule {
+          pname = "go-app";
+          version = "0.1.0";
+
+          src = ./.;
+
+          vendorHash = "sha256-jx70HhXLbBt63Vt0iZK8aUwoQnpe57MIjUMzXsnaRgA=";
+
+          nativeBuildInputs = [
+            # swag
+          ];
+
+          preBuild = ''
+            # Generate Swagger docs
+            # swag init -v3.1 -o docs -g main.go --parseDependency --parseInternal
+          '';
+
+          meta = with pkgs.lib; {
+            description = "Go application with Swagger documentation";
+            license = licenses.mit;
+          };
+        };
+      in {
+        packages = {
+          default = app;
+          app = app;
+        };
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            go_1_25
+            gopls
+            golangci-lint
+
+            air
+            # swag
+
+            # sqlc
+            # go-migrate-pg
+            # sql-formatter
+
+            pre-commit
+          ];
+
+          shellHook = ''
+            echo "Go development environment ready"
+            echo "Go version: $(go version)"
+            # echo "Swag version: $(swag --version)"
+          '';
+        };
+      }
+    );
+}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/moonrhythm/validator v1.3.0 // indirect
+	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	golang.org/x/net v0.18.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/moonrhythm/validator v1.3.0/go.mod h1:gbDyBOwWGzphP8K2Sdrd9+MveRVxzxm
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=

--- a/internal/runner/helper.go
+++ b/internal/runner/helper.go
@@ -1,0 +1,74 @@
+package runner
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func splitCommaList(s string) []string {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// format: "K=V,A=B" (values may be empty). No escaping; keep it simple like existing flags.
+func parseKVList(s string) map[string]string {
+	m := map[string]string{}
+	for _, pair := range splitCommaList(s) {
+		if eq := strings.IndexByte(pair, '='); eq >= 0 {
+			k := strings.TrimSpace(pair[:eq])
+			v := strings.TrimSpace(pair[eq+1:])
+			if k != "" {
+				m[k] = v
+			}
+		} else if pair != "" {
+			// allow "KEY" -> empty value
+			m[pair] = ""
+		}
+	}
+	return m
+}
+
+// supports "@path" to read file content; otherwise returns value as-is
+func readMaybeFile(value string) (string, error) {
+	if strings.HasPrefix(value, "@") && len(value) > 1 {
+		b, err := os.ReadFile(value[1:])
+		if err != nil {
+			return "", err
+		}
+		return string(b), nil
+	}
+	return value, nil
+}
+
+// format: "/path=VALUE,/path2=@file.txt"
+func parseMountData(s string) (map[string]string, error) {
+	m := map[string]string{}
+	for _, pair := range splitCommaList(s) {
+		if eq := strings.IndexByte(pair, '='); eq >= 0 {
+			k := strings.TrimSpace(pair[:eq])
+			v := strings.TrimSpace(pair[eq+1:])
+			if k == "" || !strings.HasPrefix(k, "/") {
+				return nil, fmt.Errorf("mountData key must be absolute path: %q", k)
+			}
+			val, err := readMaybeFile(v)
+			if err != nil {
+				return nil, err
+			}
+			m[k] = val
+		} else if pair != "" {
+			return nil, fmt.Errorf("mountData must be key=value: %q", pair)
+		}
+	}
+	return m, nil
+}


### PR DESCRIPTION
# Background
I was bored when I used deploys.app GitHub action. I cannot set the deploy type, e.g. when I want to deploy a Discord bot, I have to log in to deploys.app and deploy the broken deployments first because I cannot change the deploy type to use the action. This CLI will make it possible for me to add more flags in deploys.app GitHub action.

# Change
- Introduced Nix flake support by adding `.envrc` and `flake.nix` files, enabling reproducible development environments with Go tooling and dependencies. (It's just a dev dependency. Tell me if you want me to remove it. It’s nice to have for other contributors.)
- Refactored the deployment logic in `internal/runner/runner.go` by moving the "deploy" subcommand into a new `deploymentDeploy` function, enabling easier maintenance and extension.
- Implemented input validation for deployment type and protocol, and cron schedule format using the `robfig/cron/v3` library.