### PR TITLE
Add github commands: link, unlink, list

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/deploys-app/deploys
 
-go 1.24
+go 1.26
 
 require (
-	github.com/deploys-app/api v0.0.0-20250307165715-af46760f8f45
+	github.com/deploys-app/api v0.0.0-20260612091159-6332523a9654
 	golang.org/x/oauth2 v0.14.0
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:W
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deploys-app/api v0.0.0-20250307165715-af46760f8f45 h1:pX2JVDIud/IMfpvqVnc1SuVQjD4eWJaiJtorh7CeUYc=
-github.com/deploys-app/api v0.0.0-20250307165715-af46760f8f45/go.mod h1:7aMzMAb0JD8TK9ayMTbysSQjv010nUTCJn5fSRSb2GA=
+github.com/deploys-app/api v0.0.0-20260612091159-6332523a9654 h1:Ucga9bk7Tl0PWeBUX0Oy6LGZNzsClHnVSQvWOTU8y+o=
+github.com/deploys-app/api v0.0.0-20260612091159-6332523a9654/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -114,6 +114,8 @@ func (rn Runner) Run(args ...string) error {
 		return rn.workloadIdentity(args[1:]...)
 	case "serviceaccount", "sa":
 		return rn.serviceAccount(args[1:]...)
+	case "github":
+		return rn.github(args[1:]...)
 	case "collector":
 		return rn.collector(args[1:]...)
 	}
@@ -744,6 +746,77 @@ func (rn Runner) serviceAccount(args ...string) error {
 		f.StringVar(&req.Secret, "secret", "", "secret")
 		f.Parse(args[1:])
 		resp, err = s.DeleteKey(context.Background(), &req)
+	}
+	if err != nil {
+		return err
+	}
+	return rn.print(resp)
+}
+
+func (rn Runner) github(args ...string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("invalid command")
+	}
+
+	s := rn.API.GitHub()
+
+	var (
+		resp any
+		err  error
+	)
+
+	f := flag.NewFlagSet("", flag.ExitOnError)
+	rn.registerFlags(f)
+	switch args[0] {
+	default:
+		return fmt.Errorf("invalid command")
+	case "link":
+		var (
+			req        api.GitHubLink
+			repository string
+		)
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&repository, "repository", "", "repository (owner/name)")
+		f.StringVar(&req.ServiceAccount, "service-account", "", "service account id")
+		f.Parse(args[1:])
+		// Resolve owner/name to the immutable repository id through the
+		// github app — this also verifies the app is installed on the repo.
+		lookup, lerr := s.LookupRepo(context.Background(), &api.GitHubLookupRepo{
+			Project:    req.Project,
+			Repository: repository,
+		})
+		if lerr != nil {
+			return lerr
+		}
+		req.RepositoryID = lookup.RepositoryID
+		req.Repository = lookup.Repository
+		req.InstallationID = lookup.InstallationID
+		resp, err = s.Link(context.Background(), &req)
+	case "unlink":
+		var (
+			req        api.GitHubUnlink
+			repository string
+		)
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&repository, "repository", "", "repository (owner/name)")
+		f.Int64Var(&req.RepositoryID, "repository-id", 0, "github repository id (alternative to -repository)")
+		f.Parse(args[1:])
+		if req.RepositoryID == 0 && repository != "" {
+			lookup, lerr := s.LookupRepo(context.Background(), &api.GitHubLookupRepo{
+				Project:    req.Project,
+				Repository: repository,
+			})
+			if lerr != nil {
+				return lerr
+			}
+			req.RepositoryID = lookup.RepositoryID
+		}
+		resp, err = s.Unlink(context.Background(), &req)
+	case "list":
+		var req api.GitHubList
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.Parse(args[1:])
+		resp, err = s.List(context.Background(), &req)
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

CLI side of the GitHub build & deploy feature (api#43/#46, apiserver#100/#102/#104):

- `deploys github link -project=<p> -repository=<owner/name> -service-account=<sid>` — resolves owner/name via `github.lookupRepo` (immutable repository id; fails with "github app is not installed on the repository" if the App doesn't cover it) and creates the link.
- `deploys github unlink -project=<p> -repository=<owner/name>` (or `-repository-id=<n>`).
- `deploys github list -project=<p>` — table output via the api's `Table()`.

Also bumps `github.com/deploys-app/api` from 2025-03 to current main (builds clean) and go 1.24→1.26 via go.mod tooling.

The docs "Deploy from GitHub" guide (docs PR) references these commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)