### PR TITLE
Add commands for all core apis

### DIFF
--- a/internal/runner/auditlog.go
+++ b/internal/runner/auditlog.go
@@ -1,0 +1,57 @@
+package runner
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/deploys-app/api"
+)
+
+func (rn Runner) auditLog(args ...string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("invalid command")
+	}
+
+	s := rn.API.AuditLog()
+
+	var (
+		resp any
+		err  error
+	)
+
+	f := flag.NewFlagSet("", flag.ExitOnError)
+	rn.registerFlags(f)
+	switch args[0] {
+	default:
+		return fmt.Errorf("invalid command")
+	case "list":
+		var (
+			req     api.AuditLogList
+			outcome string
+		)
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.ResourceType, "resource-type", "", "filter by resource type")
+		f.StringVar(&req.Actor, "actor", "", "filter by actor email")
+		f.StringVar(&outcome, "outcome", "", "filter by outcome (success, failure)")
+		f.Var(timeFlag{&req.After}, "after", "only entries after this time (RFC 3339 or YYYY-MM-DD)")
+		f.Var(timeFlag{&req.Before}, "before", "only entries before this time (RFC 3339 or YYYY-MM-DD)")
+		f.IntVar(&req.Limit, "limit", 0, "max entries")
+		f.Parse(args[1:])
+
+		switch outcome {
+		case "":
+		case api.AuditOutcomeSuccess.String():
+			req.Outcome = api.AuditOutcomeSuccess
+		case api.AuditOutcomeFailure.String():
+			req.Outcome = api.AuditOutcomeFailure
+		default:
+			return fmt.Errorf("invalid outcome: '%s'", outcome)
+		}
+		resp, err = s.List(context.Background(), &req)
+	}
+	if err != nil {
+		return err
+	}
+	return rn.print(resp)
+}

--- a/internal/runner/billing.go
+++ b/internal/runner/billing.go
@@ -1,0 +1,102 @@
+package runner
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/deploys-app/api"
+)
+
+func (rn Runner) billing(args ...string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("invalid command")
+	}
+
+	s := rn.API.Billing()
+
+	var (
+		resp any
+		err  error
+	)
+
+	f := flag.NewFlagSet("", flag.ExitOnError)
+	rn.registerFlags(f)
+	switch args[0] {
+	default:
+		return fmt.Errorf("invalid command")
+	case "create":
+		var req api.BillingCreate
+		f.StringVar(&req.Name, "name", "", "billing account name")
+		f.StringVar(&req.TaxID, "tax-id", "", "tax id")
+		f.StringVar(&req.TaxName, "tax-name", "", "tax name")
+		f.StringVar(&req.TaxAddress, "tax-address", "", "tax address")
+		f.Parse(args[1:])
+		resp, err = s.Create(context.Background(), &req)
+	case "list":
+		f.Parse(args[1:])
+		resp, err = s.List(context.Background(), &api.Empty{})
+	case "get":
+		var req api.BillingGet
+		f.Int64Var(&req.ID, "id", 0, "billing account id")
+		f.Parse(args[1:])
+		resp, err = s.Get(context.Background(), &req)
+	case "update":
+		var req api.BillingUpdate
+		f.Int64Var(&req.ID, "id", 0, "billing account id")
+		f.StringVar(&req.Name, "name", "", "billing account name")
+		f.StringVar(&req.TaxID, "tax-id", "", "tax id")
+		f.StringVar(&req.TaxName, "tax-name", "", "tax name")
+		f.StringVar(&req.TaxAddress, "tax-address", "", "tax address")
+		f.Parse(args[1:])
+		resp, err = s.Update(context.Background(), &req)
+	case "delete":
+		var req api.BillingDelete
+		f.Int64Var(&req.ID, "id", 0, "billing account id")
+		f.Parse(args[1:])
+		resp, err = s.Delete(context.Background(), &req)
+	case "report":
+		var (
+			req      api.BillingReport
+			projects string
+		)
+		f.Int64Var(&req.ID, "id", 0, "billing account id")
+		f.StringVar(&req.Range, "range", "", "report range")
+		f.StringVar(&projects, "projects", "", "project ids (comma separated values, empty = all)")
+		f.Parse(args[1:])
+		req.ProjectSIDs = splitComma(projects)
+		resp, err = s.Report(context.Background(), &req)
+	case "skus":
+		f.Parse(args[1:])
+		resp, err = s.SKUs(context.Background(), &api.Empty{})
+	case "project":
+		var req api.BillingProject
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.Parse(args[1:])
+		resp, err = s.Project(context.Background(), &req)
+	case "invoices":
+		var req api.InvoiceList
+		f.Int64Var(&req.BillingAccountID, "id", 0, "billing account id")
+		f.Parse(args[1:])
+		resp, err = s.ListInvoices(context.Background(), &req)
+	case "invoice":
+		var req api.InvoiceGet
+		f.Int64Var(&req.InvoiceID, "id", 0, "invoice id")
+		f.Parse(args[1:])
+		resp, err = s.GetInvoice(context.Background(), &req)
+	case "downloadinvoice":
+		var req api.InvoiceGet
+		f.Int64Var(&req.InvoiceID, "id", 0, "invoice id")
+		f.Parse(args[1:])
+		resp, err = s.DownloadInvoice(context.Background(), &req)
+	case "downloadreceipt":
+		var req api.InvoiceGet
+		f.Int64Var(&req.InvoiceID, "id", 0, "invoice id")
+		f.Parse(args[1:])
+		resp, err = s.DownloadReceipt(context.Background(), &req)
+	}
+	if err != nil {
+		return err
+	}
+	return rn.print(resp)
+}

--- a/internal/runner/domain.go
+++ b/internal/runner/domain.go
@@ -1,0 +1,67 @@
+package runner
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/deploys-app/api"
+)
+
+func (rn Runner) domain(args ...string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("invalid command")
+	}
+
+	s := rn.API.Domain()
+
+	var (
+		resp any
+		err  error
+	)
+
+	f := flag.NewFlagSet("", flag.ExitOnError)
+	rn.registerFlags(f)
+	switch args[0] {
+	default:
+		return fmt.Errorf("invalid command")
+	case "create":
+		var req api.DomainCreate
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Location, "location", "", "location")
+		f.StringVar(&req.Domain, "domain", "", "domain")
+		f.BoolVar(&req.Wildcard, "wildcard", false, "wildcard domain")
+		f.Parse(args[1:])
+		resp, err = s.Create(context.Background(), &req)
+	case "get":
+		var req api.DomainGet
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Domain, "domain", "", "domain")
+		f.Parse(args[1:])
+		resp, err = s.Get(context.Background(), &req)
+	case "list":
+		var req api.DomainList
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Location, "location", "", "location")
+		f.Parse(args[1:])
+		resp, err = s.List(context.Background(), &req)
+	case "delete":
+		var req api.DomainDelete
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Domain, "domain", "", "domain")
+		f.Parse(args[1:])
+		resp, err = s.Delete(context.Background(), &req)
+	case "purgecache":
+		var req api.DomainPurgeCache
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Domain, "domain", "", "domain")
+		f.StringVar(&req.File, "file", "", "purge a single file path")
+		f.StringVar(&req.Prefix, "prefix", "", "purge all files under a path prefix")
+		f.Parse(args[1:])
+		resp, err = s.PurgeCache(context.Background(), &req)
+	}
+	if err != nil {
+		return err
+	}
+	return rn.print(resp)
+}

--- a/internal/runner/dropbox.go
+++ b/internal/runner/dropbox.go
@@ -1,0 +1,51 @@
+package runner
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/deploys-app/api"
+)
+
+func (rn Runner) dropbox(args ...string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("invalid command")
+	}
+
+	s := rn.API.Dropbox()
+
+	var (
+		resp any
+		err  error
+	)
+
+	f := flag.NewFlagSet("", flag.ExitOnError)
+	rn.registerFlags(f)
+	switch args[0] {
+	default:
+		return fmt.Errorf("invalid command")
+	case "list":
+		var req api.DropboxList
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.Var(timeFlag{&req.After}, "after", "only files after this time (RFC 3339 or YYYY-MM-DD)")
+		f.Var(timeFlag{&req.Before}, "before", "only files before this time (RFC 3339 or YYYY-MM-DD)")
+		f.IntVar(&req.Limit, "limit", 0, "max entries")
+		f.Parse(args[1:])
+		resp, err = s.List(context.Background(), &req)
+	case "metrics":
+		var (
+			req       api.DropboxMetrics
+			timeRange string
+		)
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&timeRange, "time-range", "30d", "time range (7d, 30d, 90d)")
+		f.Parse(args[1:])
+		req.TimeRange = api.UsageMetricsTimeRange(timeRange)
+		resp, err = s.Metrics(context.Background(), &req)
+	}
+	if err != nil {
+		return err
+	}
+	return rn.print(resp)
+}

--- a/internal/runner/email.go
+++ b/internal/runner/email.go
@@ -1,0 +1,77 @@
+package runner
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/deploys-app/api"
+)
+
+func (rn Runner) email(args ...string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("invalid command")
+	}
+
+	s := rn.API.Email()
+
+	var (
+		resp any
+		err  error
+	)
+
+	f := flag.NewFlagSet("", flag.ExitOnError)
+	rn.registerFlags(f)
+	switch args[0] {
+	default:
+		return fmt.Errorf("invalid command")
+	case "send":
+		var (
+			req         api.EmailSend
+			to          string
+			typ         string
+			content     string
+			contentFile string
+		)
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.From.Email, "from", "", "from email")
+		f.StringVar(&req.From.Name, "from-name", "", "from name")
+		f.StringVar(&to, "to", "", "to emails (comma separated values)")
+		f.StringVar(&req.Subject, "subject", "", "subject")
+		f.StringVar(&typ, "type", "text", "body type (text, html)")
+		f.StringVar(&content, "content", "", "body content")
+		f.StringVar(&contentFile, "content-file", "", "read body content from file")
+		f.Parse(args[1:])
+
+		for _, addr := range splitComma(to) {
+			req.To = append(req.To, api.EmailAddr{Email: addr})
+		}
+		switch typ {
+		case "text", string(api.EmailTypeText):
+			req.Body.Type = api.EmailTypeText
+		case "html", string(api.EmailTypeHTML):
+			req.Body.Type = api.EmailTypeHTML
+		default:
+			return fmt.Errorf("invalid body type: '%s'", typ)
+		}
+		if contentFile != "" {
+			b, ferr := os.ReadFile(contentFile)
+			if ferr != nil {
+				return ferr
+			}
+			content = string(b)
+		}
+		req.Body.Content = content
+		resp, err = s.Send(context.Background(), &req)
+	case "list":
+		var req api.EmailList
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.Parse(args[1:])
+		resp, err = s.List(context.Background(), &req)
+	}
+	if err != nil {
+		return err
+	}
+	return rn.print(resp)
+}

--- a/internal/runner/envgroup.go
+++ b/internal/runner/envgroup.go
@@ -1,0 +1,87 @@
+package runner
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/deploys-app/api"
+)
+
+func (rn Runner) envGroup(args ...string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("invalid command")
+	}
+
+	s := rn.API.EnvGroup()
+
+	var (
+		resp any
+		err  error
+	)
+
+	f := flag.NewFlagSet("", flag.ExitOnError)
+	rn.registerFlags(f)
+	switch args[0] {
+	default:
+		return fmt.Errorf("invalid command")
+	case "create":
+		var (
+			req api.EnvGroupCreate
+			env multiFlag
+		)
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Name, "name", "", "env group name")
+		f.Var(&env, "env", "env KEY=VALUE (repeatable)")
+		f.Parse(args[1:])
+		req.Env, err = parseKV(env)
+		if err != nil {
+			return err
+		}
+		resp, err = s.Create(context.Background(), &req)
+	case "get":
+		var req api.EnvGroupGet
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Name, "name", "", "env group name")
+		f.Parse(args[1:])
+		resp, err = s.Get(context.Background(), &req)
+	case "list":
+		var req api.EnvGroupList
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.Parse(args[1:])
+		resp, err = s.List(context.Background(), &req)
+	case "update":
+		var (
+			req       api.EnvGroupUpdate
+			env       multiFlag
+			addEnv    multiFlag
+			removeEnv string
+		)
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Name, "name", "", "env group name")
+		f.Var(&env, "env", "env KEY=VALUE, replaces all existing env (repeatable)")
+		f.Var(&addEnv, "add-env", "env KEY=VALUE to add to existing env (repeatable)")
+		f.StringVar(&removeEnv, "remove-env", "", "env keys to remove (comma separated values)")
+		f.Parse(args[1:])
+		req.Env, err = parseKV(env)
+		if err != nil {
+			return err
+		}
+		req.AddEnv, err = parseKV(addEnv)
+		if err != nil {
+			return err
+		}
+		req.RemoveEnv = splitComma(removeEnv)
+		resp, err = s.Update(context.Background(), &req)
+	case "delete":
+		var req api.EnvGroupDelete
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Name, "name", "", "env group name")
+		f.Parse(args[1:])
+		resp, err = s.Delete(context.Background(), &req)
+	}
+	if err != nil {
+		return err
+	}
+	return rn.print(resp)
+}

--- a/internal/runner/flags.go
+++ b/internal/runner/flags.go
@@ -1,0 +1,72 @@
+package runner
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// multiFlag collects a repeatable string flag (e.g. -env A=1 -env B=2).
+type multiFlag []string
+
+func (m *multiFlag) String() string {
+	return strings.Join(*m, ",")
+}
+
+func (m *multiFlag) Set(v string) error {
+	*m = append(*m, v)
+	return nil
+}
+
+// parseKV parses KEY=VALUE pairs into a map. Returns nil on empty input so
+// untouched request fields stay nil.
+func parseKV(kvs []string) (map[string]string, error) {
+	if len(kvs) == 0 {
+		return nil, nil
+	}
+	res := make(map[string]string, len(kvs))
+	for _, kv := range kvs {
+		k, v, ok := strings.Cut(kv, "=")
+		if !ok || k == "" {
+			return nil, fmt.Errorf("invalid KEY=VALUE pair: '%s'", kv)
+		}
+		res[k] = v
+	}
+	return res, nil
+}
+
+// timeFlag parses an RFC 3339 timestamp or a date (2006-01-02) into time.Time.
+type timeFlag struct {
+	t *time.Time
+}
+
+func (f timeFlag) String() string {
+	if f.t == nil || f.t.IsZero() {
+		return ""
+	}
+	return f.t.Format(time.RFC3339)
+}
+
+func (f timeFlag) Set(v string) error {
+	for _, layout := range []string{time.RFC3339, "2006-01-02"} {
+		t, err := time.Parse(layout, v)
+		if err == nil {
+			*f.t = t
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid time '%s' (want RFC 3339 or YYYY-MM-DD)", v)
+}
+
+// splitComma splits a comma separated value, dropping empty elements.
+// Returns nil on empty input.
+func splitComma(s string) []string {
+	var res []string
+	for _, x := range strings.Split(s, ",") {
+		x = strings.TrimSpace(x)
+		if x != "" {
+			res = append(res, x)
+		}
+	}
+	return res
+}

--- a/internal/runner/flags_test.go
+++ b/internal/runner/flags_test.go
@@ -1,0 +1,64 @@
+package runner
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseKV(t *testing.T) {
+	m, err := parseKV(nil)
+	if err != nil || m != nil {
+		t.Errorf("parseKV(nil) = %v, %v; want nil, nil", m, err)
+	}
+
+	m, err = parseKV([]string{"A=1", "B=x=y", "C="})
+	if err != nil {
+		t.Fatalf("parseKV() error: %v", err)
+	}
+	if m["A"] != "1" || m["B"] != "x=y" || m["C"] != "" {
+		t.Errorf("parseKV() = %v", m)
+	}
+
+	for _, kv := range []string{"A", "=1"} {
+		_, err = parseKV([]string{kv})
+		if err == nil {
+			t.Errorf("parseKV(%q) want error", kv)
+		}
+	}
+}
+
+func TestTimeFlag(t *testing.T) {
+	var v time.Time
+	f := timeFlag{&v}
+
+	err := f.Set("2026-06-12")
+	if err != nil {
+		t.Fatalf("Set(date) error: %v", err)
+	}
+	if v.Format("2006-01-02") != "2026-06-12" {
+		t.Errorf("Set(date) = %v", v)
+	}
+
+	err = f.Set("2026-06-12T10:30:00Z")
+	if err != nil {
+		t.Fatalf("Set(rfc3339) error: %v", err)
+	}
+	if !v.Equal(time.Date(2026, 6, 12, 10, 30, 0, 0, time.UTC)) {
+		t.Errorf("Set(rfc3339) = %v", v)
+	}
+
+	err = f.Set("yesterday")
+	if err == nil {
+		t.Error("Set(invalid) want error")
+	}
+}
+
+func TestSplitComma(t *testing.T) {
+	if got := splitComma(""); got != nil {
+		t.Errorf("splitComma(\"\") = %v; want nil", got)
+	}
+	got := splitComma("a, b,,c")
+	if len(got) != 3 || got[0] != "a" || got[1] != "b" || got[2] != "c" {
+		t.Errorf("splitComma() = %v", got)
+	}
+}

--- a/internal/runner/registry.go
+++ b/internal/runner/registry.go
@@ -1,0 +1,91 @@
+package runner
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/deploys-app/api"
+)
+
+func (rn Runner) registry(args ...string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("invalid command")
+	}
+
+	s := rn.API.Registry()
+
+	var (
+		resp any
+		err  error
+	)
+
+	f := flag.NewFlagSet("", flag.ExitOnError)
+	rn.registerFlags(f)
+	switch args[0] {
+	default:
+		return fmt.Errorf("invalid command")
+	case "list":
+		var req api.RegistryList
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.Parse(args[1:])
+		resp, err = s.List(context.Background(), &req)
+	case "get":
+		var req api.RegistryGet
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Repository, "repository", "", "repository name")
+		f.Parse(args[1:])
+		resp, err = s.Get(context.Background(), &req)
+	case "tags":
+		var req api.RegistryGetTags
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Repository, "repository", "", "repository name")
+		f.Parse(args[1:])
+		resp, err = s.GetTags(context.Background(), &req)
+	case "manifests":
+		var req api.RegistryGetManifests
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Repository, "repository", "", "repository name")
+		f.Parse(args[1:])
+		resp, err = s.GetManifests(context.Background(), &req)
+	case "storage":
+		var req api.RegistryGetProjectStorage
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.Parse(args[1:])
+		resp, err = s.GetProjectStorage(context.Background(), &req)
+	case "delete":
+		var req api.RegistryDelete
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Repository, "repository", "", "repository name")
+		f.Parse(args[1:])
+		resp, err = s.Delete(context.Background(), &req)
+	case "deletemanifest":
+		var req api.RegistryDeleteManifest
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Repository, "repository", "", "repository name")
+		f.StringVar(&req.Digest, "digest", "", "manifest digest")
+		f.Parse(args[1:])
+		resp, err = s.DeleteManifest(context.Background(), &req)
+	case "untag":
+		var req api.RegistryUntag
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Repository, "repository", "", "repository name")
+		f.StringVar(&req.Tag, "tag", "", "tag")
+		f.Parse(args[1:])
+		resp, err = s.Untag(context.Background(), &req)
+	case "metrics":
+		var (
+			req       api.RegistryMetrics
+			timeRange string
+		)
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&timeRange, "time-range", "30d", "time range (7d, 30d, 90d)")
+		f.Parse(args[1:])
+		req.TimeRange = api.UsageMetricsTimeRange(timeRange)
+		resp, err = s.Metrics(context.Background(), &req)
+	}
+	if err != nil {
+		return err
+	}
+	return rn.print(resp)
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -33,7 +33,12 @@ func (rn Runner) output() *os.File {
 func (rn Runner) print(v any) error {
 	switch rn.OutputMode {
 	case "", "table":
-		rn.printTable(v.(tablePrinter).Table())
+		tp, ok := v.(tablePrinter)
+		if !ok {
+			// no table representation, fall back to yaml
+			return yaml.NewEncoder(rn.output()).Encode(v)
+		}
+		rn.printTable(tp.Table())
 		return nil
 	case "yaml":
 		return yaml.NewEncoder(rn.output()).Encode(v)
@@ -96,6 +101,8 @@ func (rn Runner) Run(args ...string) error {
 		return fmt.Errorf("invalid command: '%s'", args[0])
 	case "me":
 		return rn.me(args[1:]...)
+	case "billing":
+		return rn.billing(args[1:]...)
 	case "location":
 		return rn.location(args[1:]...)
 	case "project":
@@ -104,8 +111,12 @@ func (rn Runner) Run(args ...string) error {
 		return rn.role(args[1:]...)
 	case "deployment", "deploy", "d":
 		return rn.deployment(args[1:]...)
+	case "domain":
+		return rn.domain(args[1:]...)
 	case "route":
 		return rn.route(args[1:]...)
+	case "waf":
+		return rn.waf(args[1:]...)
 	case "disk":
 		return rn.disk(args[1:]...)
 	case "pullsecret", "ps":
@@ -114,6 +125,16 @@ func (rn Runner) Run(args ...string) error {
 		return rn.workloadIdentity(args[1:]...)
 	case "serviceaccount", "sa":
 		return rn.serviceAccount(args[1:]...)
+	case "email":
+		return rn.email(args[1:]...)
+	case "registry":
+		return rn.registry(args[1:]...)
+	case "envgroup", "eg":
+		return rn.envGroup(args[1:]...)
+	case "auditlog":
+		return rn.auditLog(args[1:]...)
+	case "dropbox":
+		return rn.dropbox(args[1:]...)
 	case "github":
 		return rn.github(args[1:]...)
 	case "collector":
@@ -381,6 +402,47 @@ func (rn Runner) deployment(args ...string) error {
 		f.StringVar(&req.Name, "name", "", "deployment name")
 		f.Parse(args[1:])
 		resp, err = s.Delete(context.Background(), &req)
+	case "revisions":
+		var req api.DeploymentRevisions
+		f.StringVar(&req.Location, "location", "", "location")
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Name, "name", "", "deployment name")
+		f.Parse(args[1:])
+		resp, err = s.Revisions(context.Background(), &req)
+	case "pause":
+		var req api.DeploymentPause
+		f.StringVar(&req.Location, "location", "", "location")
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Name, "name", "", "deployment name")
+		f.Parse(args[1:])
+		resp, err = s.Pause(context.Background(), &req)
+	case "resume":
+		var req api.DeploymentResume
+		f.StringVar(&req.Location, "location", "", "location")
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Name, "name", "", "deployment name")
+		f.Parse(args[1:])
+		resp, err = s.Resume(context.Background(), &req)
+	case "rollback":
+		var req api.DeploymentRollback
+		f.StringVar(&req.Location, "location", "", "location")
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Name, "name", "", "deployment name")
+		f.IntVar(&req.Revision, "revision", 0, "revision to rollback to")
+		f.Parse(args[1:])
+		resp, err = s.Rollback(context.Background(), &req)
+	case "metrics":
+		var (
+			req       api.DeploymentMetrics
+			timeRange string
+		)
+		f.StringVar(&req.Location, "location", "", "location")
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Name, "name", "", "deployment name")
+		f.StringVar(&timeRange, "time-range", "1h", "time range (1h, 6h, 12h, 1d)")
+		f.Parse(args[1:])
+		req.TimeRange = api.DeploymentMetricsTimeRange(timeRange)
+		resp, err = s.Metrics(context.Background(), &req)
 	case "deploy":
 		var (
 			req         api.DeploymentDeploy

--- a/internal/runner/waf.go
+++ b/internal/runner/waf.go
@@ -1,0 +1,115 @@
+package runner
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/deploys-app/api"
+	"gopkg.in/yaml.v2"
+)
+
+func (rn Runner) waf(args ...string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("invalid command")
+	}
+
+	s := rn.API.WAF()
+
+	var (
+		resp any
+		err  error
+	)
+
+	f := flag.NewFlagSet("", flag.ExitOnError)
+	rn.registerFlags(f)
+	switch args[0] {
+	default:
+		return fmt.Errorf("invalid command")
+	case "get":
+		var req api.WAFGet
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Location, "location", "", "location")
+		f.Parse(args[1:])
+		resp, err = s.Get(context.Background(), &req)
+	case "list":
+		var req api.WAFList
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.Parse(args[1:])
+		resp, err = s.List(context.Background(), &req)
+	case "set":
+		// Set replaces the whole zone (rules and limits) all-or-nothing, so it
+		// takes a spec file rather than per-rule flags. The file is the yaml
+		// form of waf get (description, rules, limits); project and location
+		// flags override values in the file.
+		var (
+			fn          string
+			project     string
+			location    string
+			description string
+		)
+		f.StringVar(&fn, "f", "", "spec file (yaml: description, rules, limits)")
+		f.StringVar(&project, "project", "", "project id")
+		f.StringVar(&location, "location", "", "location")
+		f.StringVar(&description, "description", "", "zone description")
+		f.Parse(args[1:])
+
+		if fn == "" {
+			return fmt.Errorf("spec file required (-f)")
+		}
+		b, ferr := os.ReadFile(fn)
+		if ferr != nil {
+			return ferr
+		}
+		// non-strict so the yaml output of `waf get` (which carries extra
+		// read-only fields) can be edited and fed back in
+		var req api.WAFSet
+		ferr = yaml.Unmarshal(b, &req)
+		if ferr != nil {
+			return fmt.Errorf("parse %s: %w", fn, ferr)
+		}
+		if project != "" {
+			req.Project = project
+		}
+		if location != "" {
+			req.Location = location
+		}
+		if description != "" {
+			req.Description = description
+		}
+		resp, err = s.Set(context.Background(), &req)
+	case "delete":
+		var req api.WAFDelete
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Location, "location", "", "location")
+		f.Parse(args[1:])
+		resp, err = s.Delete(context.Background(), &req)
+	case "metrics":
+		var (
+			req       api.WAFMetrics
+			timeRange string
+		)
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Location, "location", "", "location")
+		f.StringVar(&timeRange, "time-range", "1h", "time range (1h, 6h, 12h, 1d, 7d, 30d)")
+		f.Parse(args[1:])
+		req.TimeRange = api.WAFMetricsTimeRange(timeRange)
+		resp, err = s.Metrics(context.Background(), &req)
+	case "limitmetrics":
+		var (
+			req       api.WAFLimitMetrics
+			timeRange string
+		)
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Location, "location", "", "location")
+		f.StringVar(&timeRange, "time-range", "1h", "time range (1h, 6h, 12h, 1d, 7d, 30d)")
+		f.Parse(args[1:])
+		req.TimeRange = api.WAFMetricsTimeRange(timeRange)
+		resp, err = s.LimitMetrics(context.Background(), &req)
+	}
+	if err != nil {
+		return err
+	}
+	return rn.print(resp)
+}

--- a/main.go
+++ b/main.go
@@ -76,5 +76,40 @@ func getDefaultToken() (string, error) {
 }
 
 func help() {
-	fmt.Println("deploys.app cli")
+	fmt.Print(`deploys.app cli
+
+Usage:
+  deploys <command> <subcommand> [flags]
+
+Commands:
+  me                      get, authorized
+  billing                 create, list, get, update, delete, report, skus, project,
+                          invoices, invoice, downloadinvoice, downloadreceipt
+  location                list, get
+  project                 create, list, get, update, delete, usage
+  role                    create, list, get, delete, grant, revoke, users, bind
+  deployment, deploy, d   list, get, deploy, delete, revisions, pause, resume,
+                          rollback, metrics, set
+  domain                  create, get, list, delete, purgecache
+  route                   create, get, list, delete
+  waf                     get, list, set, delete, metrics, limitmetrics
+  disk                    create, get, list, update, delete
+  pullsecret, ps          create, get, list, delete
+  workloadidentity, wi    create, get, list, delete
+  serviceaccount, sa      create, get, list, update, delete, createkey, deletekey
+  email                   send, list
+  registry                list, get, tags, manifests, storage, delete,
+                          deletemanifest, untag, metrics
+  envgroup, eg            create, get, list, update, delete
+  auditlog                list
+  dropbox                 list, metrics
+  github                  link, unlink, list
+
+Flags:
+  -output table|yaml|json (or -oyaml, -ojson, -otable)
+
+Environment:
+  DEPLOYS_TOKEN           api token
+  DEPLOYS_ENDPOINT        override api endpoint
+`)
 }


### PR DESCRIPTION
Extends the CLI to cover every user-facing service in `api.Interface`. Previously only about half the surface was reachable from the CLI.

## New commands

| Command | Subcommands |
|---|---|
| `billing` | create, list, get, update, delete, report, skus, project, invoices, invoice, downloadinvoice, downloadreceipt |
| `domain` | create, get, list, delete, purgecache |
| `waf` | get, list, set, delete, metrics, limitmetrics |
| `registry` | list, get, tags, manifests, storage, delete, deletemanifest, untag, metrics |
| `envgroup` (`eg`) | create, get, list, update, delete |
| `email` | send, list |
| `auditlog` | list |
| `dropbox` | list, metrics |

## Completed commands

- `deployment` gains the missing methods: `revisions`, `pause`, `resume`, `rollback`, `metrics`.

## Behavior changes

- **Table fallback**: results without a `Table()` implementation now print as yaml in table mode instead of panicking on the type assertion (this was a latent panic — e.g. `deployment get` in default output mode).
- **Help**: bare `deploys` now prints the full command list instead of just `deploys.app cli`.

## Design notes

- `waf set` takes a spec file (`-f spec.yaml`) rather than per-rule flags, since `waf.set` replaces the whole zone all-or-nothing. The file is parsed non-strictly so `waf get -oyaml > spec.yaml` → edit → `waf set -f spec.yaml` round-trips (the get output carries read-only fields). `-f` is required so a bare `waf set` can't wipe a zone's rules by accident.
- `envgroup` env vars use repeatable flags (`-env KEY=VALUE -env K2=V2`); `update` supports `-env` (replace all), `-add-env`, and `-remove-env k1,k2`.
- `auditlog`/`dropbox` time filters accept RFC 3339 or `YYYY-MM-DD`.
- Not exposed: `Deployer` and `Collector` (machine-to-machine APIs), and the multipart endpoints the Go client stubs out (`me.uploadKYCDocument`, `billing.uploadTransferSlip`).

## Testing

- `go build` / `go vet` / `go test` pass; new unit tests for the flag helpers.
- Smoke-tested against the live API (read-only): `location list`, `project list`, `billing skus` (yaml fallback), `registry list`, `domain list`, `waf list`, `envgroup list`, `auditlog list`, `deployment revisions`; plus all client-side validation error paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)