### PR TITLE
github: add `github update` command + link trigger/branch flags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/deploys-app/deploys
 go 1.26
 
 require (
-	github.com/deploys-app/api v0.0.0-20260612091159-6332523a9654
+	github.com/deploys-app/api v0.0.0-20260614230708-052c044d7d4f
 	golang.org/x/oauth2 v0.14.0
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/deploys-app/api v0.0.0-20260612091159-6332523a9654 h1:Ucga9bk7Tl0PWeBUX0Oy6LGZNzsClHnVSQvWOTU8y+o=
 github.com/deploys-app/api v0.0.0-20260612091159-6332523a9654/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
+github.com/deploys-app/api v0.0.0-20260614230708-052c044d7d4f h1:FDPf3/YY3h1nq5nGfWR5WntMVCVCB0j3OZ6itrcTe9c=
+github.com/deploys-app/api v0.0.0-20260614230708-052c044d7d4f/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -836,11 +836,15 @@ func (rn Runner) github(args ...string) error {
 		var (
 			req        api.GitHubLink
 			repository string
+			trigger    string
 		)
 		f.StringVar(&req.Project, "project", "", "project id")
 		f.StringVar(&repository, "repository", "", "repository (owner/name)")
 		f.StringVar(&req.ServiceAccount, "service-account", "", "service account id")
+		f.StringVar(&req.ProductionBranch, "production-branch", "", "production branch (empty = any branch; ignored for -trigger pr)")
+		f.StringVar(&trigger, "trigger", "all", "deploy trigger: all | branch | pr")
 		f.Parse(args[1:])
+		req.Trigger = api.ParseGitHubTriggerString(trigger)
 		// Resolve owner/name to the immutable repository id through the
 		// github app — this also verifies the app is installed on the repo.
 		lookup, lerr := s.LookupRepo(context.Background(), &api.GitHubLookupRepo{
@@ -874,6 +878,65 @@ func (rn Runner) github(args ...string) error {
 			req.RepositoryID = lookup.RepositoryID
 		}
 		resp, err = s.Unlink(context.Background(), &req)
+	case "update":
+		var (
+			req        api.GitHubUpdate
+			repository string
+			trigger    string
+		)
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&repository, "repository", "", "repository (owner/name)")
+		f.Int64Var(&req.RepositoryID, "repository-id", 0, "github repository id (alternative to -repository)")
+		f.StringVar(&req.ServiceAccount, "service-account", "", "service account id")
+		f.StringVar(&req.ProductionBranch, "production-branch", "", "production branch (empty = any branch; ignored for -trigger pr)")
+		f.StringVar(&trigger, "trigger", "", "deploy trigger: all | branch | pr")
+		f.Parse(args[1:])
+
+		if req.RepositoryID == 0 && repository != "" {
+			lookup, lerr := s.LookupRepo(context.Background(), &api.GitHubLookupRepo{
+				Project:    req.Project,
+				Repository: repository,
+			})
+			if lerr != nil {
+				return lerr
+			}
+			req.RepositoryID = lookup.RepositoryID
+		}
+		if req.RepositoryID == 0 {
+			return fmt.Errorf("-repository or -repository-id required")
+		}
+
+		// Update is a full replace, so seed every field from the existing link
+		// and override only the flags the user actually passed — omitting a flag
+		// preserves its current value instead of resetting it.
+		list, lerr := s.List(context.Background(), &api.GitHubList{Project: req.Project})
+		if lerr != nil {
+			return lerr
+		}
+		var cur *api.GitHubLinkItem
+		for _, it := range list.Items {
+			if it.RepositoryID == req.RepositoryID {
+				cur = it
+				break
+			}
+		}
+		if cur == nil {
+			return fmt.Errorf("github: repository link not found for repository id %d", req.RepositoryID)
+		}
+		set := map[string]bool{}
+		f.Visit(func(fl *flag.Flag) { set[fl.Name] = true })
+		if !set["service-account"] {
+			req.ServiceAccount = cur.ServiceAccount
+		}
+		if !set["production-branch"] {
+			req.ProductionBranch = cur.ProductionBranch
+		}
+		if set["trigger"] {
+			req.Trigger = api.ParseGitHubTriggerString(trigger)
+		} else {
+			req.Trigger = cur.Trigger
+		}
+		resp, err = s.Update(context.Background(), &req)
 	case "list":
 		var req api.GitHubList
 		f.StringVar(&req.Project, "project", "", "project id")

--- a/main.go
+++ b/main.go
@@ -103,7 +103,7 @@ Commands:
   envgroup, eg            create, get, list, update, delete
   auditlog                list
   dropbox                 list, metrics
-  github                  link, unlink, list
+  github                  link, unlink, update, list
 
 Flags:
   -output table|yaml|json (or -oyaml, -ojson, -otable)


### PR DESCRIPTION
## What

Follow-up to the `github.update` feature (api/apiserver/console/docs shipped) — brings the edit capability to the CLI.

- **`deploys github update`** — edit a link in place: `-service-account`, `-production-branch`, `-trigger` (`all`/`branch`/`pr`). Resolves `-repository owner/name` via `lookupRepo`, or takes `-repository-id` directly.
- **`deploys github link`** gains `-production-branch` and `-trigger` — previously `link` could only ever create `all`-trigger, any-branch links (the gap noted alongside the feature).

## Full-replace safety

`github.update` is a full replace on the server. To avoid silently wiping fields, `update` seeds every field from the existing link (via `github.list`) and overrides **only the flags the user actually passed** (`flag.Visit`). So `deploys github update -repository acme/web -service-account ci2` changes just the SA and preserves the trigger + branch.

## Other

- Bumped the api pin to the merged `github.update` + deploy-trigger commit (`v0.0.0-20260614230708-052c044d7d4f`).
- Help text: `github  link, unlink, update, list`.

## Verification

This repo has no PR CI — verified locally: `go build ./...`, `go vet ./...`, and CLI smoke tests (`github update` with no args errors cleanly with `-repository or -repository-id required`; `--help` lists `update`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)