### PR TITLE
ci: bump GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,21 +8,21 @@ jobs:
     runs-on: ubuntu-latest
     name: Build
     steps:
-    - uses: actions/checkout@v3
-    - uses: google-github-actions/auth@v1
+    - uses: actions/checkout@v6
+    - uses: google-github-actions/auth@v3
       id: auth
       with:
         credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
         token_format: access_token
-    - uses: docker/login-action@v1
+    - uses: docker/login-action@v4
       with:
         registry: asia-southeast1-docker.pkg.dev
         username: oauth2accesstoken
         password: ${{ steps.auth.outputs.access_token }}
-    - uses: docker/setup-buildx-action@v2
+    - uses: docker/setup-buildx-action@v4
       with:
         version: latest
-    - uses: docker/build-push-action@v4
+    - uses: docker/build-push-action@v7
       with:
         provenance: false
         push: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,20 +7,20 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
-    - uses: actions/setup-go@v4
+    - uses: actions/setup-go@v6
       with:
         go-version: "^1.24"
-    - uses: goreleaser/goreleaser-action@v4
+    - uses: goreleaser/goreleaser-action@v7
       with:
         version: latest
         args: release --clean
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         CGO_ENABLED: 0
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: deploys
         path: dist/*


### PR DESCRIPTION
## What

Updates the `deploys` CLI workflow action dependencies to their current major releases.

### `build.yaml`
| Action | From | To |
|---|---|---|
| `actions/checkout` | v3 | **v6** |
| `google-github-actions/auth` | v1 | **v3** |
| `docker/login-action` | v1 | **v4** |
| `docker/setup-buildx-action` | v2 | **v4** |
| `docker/build-push-action` | v4 | **v7** |

### `release.yaml`
| Action | From | To |
|---|---|---|
| `actions/checkout` | v3 | **v6** |
| `actions/setup-go` | v4 | **v6** |
| `goreleaser/goreleaser-action` | v4 | **v7** |
| `actions/upload-artifact` | v4 | **v7** |

Pinned to floating major tags (matching the existing style); each `@vN` tag verified to exist.

## Breaking-change review

Read the release notes across every major in each jump range. Findings:

- **Universal: Node 24 runtime + minimum Actions Runner ≥ v2.327.1.** Every new major carries this. No impact on the GitHub-hosted `ubuntu-latest` runners these workflows use; would only affect self-hosted runners older than v2.327.1.
- **`google-github-actions/auth` v3 ("remove old parameters")** — confirmed against `action.yml@v3` that the inputs/outputs this workflow uses (`credentials_json`, `token_format`, output `access_token`) all still exist. The removed params were other deprecated ones.
- **`goreleaser/goreleaser-action` v6 ("default ~> v2")** — only changes the default GoReleaser tool version; the workflow pins `version: latest` (already v2.x on the old action too), and there is no `.goreleaser` config file to be incompatible.
- Docker actions: `provenance: false` / `push` / `tags` / `registry` / `username` / `password` / `version` inputs are stable across these majors; `provenance: false` also pre-empts attestation-default changes.

**Verdict:** safe as-is on `ubuntu-latest`; no config changes required. Caveat: a future move to self-hosted runners would need runner ≥ v2.327.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)