### PR TITLE
chore: bump Go to 1.26 and Debian base to 13 (trixie)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-go@v6
       with:
-        go-version: "^1.24"
+        go-version: "^1.26"
     - uses: goreleaser/goreleaser-action@v7
       with:
         version: latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.5-bookworm
+FROM golang:1.26.4-trixie
 
 ENV CGO_ENABLED=0
 
@@ -9,7 +9,7 @@ RUN go mod download
 ADD . .
 RUN go build -o .build/deploys -ldflags "-w -s" .
 
-FROM debian:12-slim
+FROM debian:13-slim
 
 RUN apt-get update && apt-get install -y \
   ca-certificates \


### PR DESCRIPTION
## What

`go.mod` already declares `go 1.26`, but the build image and CI were still on 1.24 — this aligns them and refreshes the Debian base.

| Where | From | To |
|---|---|---|
| `Dockerfile` build stage | `golang:1.24.5-bookworm` | `golang:1.26.4-trixie` |
| `Dockerfile` runtime stage | `debian:12-slim` | `debian:13-slim` (trixie) |
| `release.yaml` `setup-go` | `^1.24` | `^1.26` |

## Notes

- Go 1.26.4 is the current stable; `golang:1.26.4-trixie` and `debian:13-slim` both verified to exist on Docker Hub.
- The binary is built `CGO_ENABLED=0` (static), so the runtime image needs only `ca-certificates` — the Debian 12 → 13 bump carries no glibc/runtime-linkage risk.
- `go build ./...` and `go vet ./...` pass on Go 1.26.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)