### PR TITLE
deployment: full-flag deploy command + unify flag patterns

### DIFF
--- a/internal/runner/flags.go
+++ b/internal/runner/flags.go
@@ -1,10 +1,21 @@
 package runner
 
 import (
+	"flag"
 	"fmt"
 	"strings"
 	"time"
 )
+
+// visitedFlags returns the set of flag names that were explicitly provided on
+// the command line. It lets a command distinguish "flag omitted" (leave the
+// request field nil so the server keeps the previous value) from "flag set to
+// the zero value" (e.g. -ttl 0 to clear, -internal=false to set false).
+func visitedFlags(f *flag.FlagSet) map[string]bool {
+	set := map[string]bool{}
+	f.Visit(func(fl *flag.Flag) { set[fl.Name] = true })
+	return set
+}
 
 // multiFlag collects a repeatable string flag (e.g. -env A=1 -env B=2).
 type multiFlag []string

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -3,10 +3,11 @@ package runner
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
-	"strings"
 	"unicode/utf8"
 
 	"github.com/deploys-app/api"
@@ -170,7 +171,7 @@ func (rn Runner) me(args ...string) error {
 		f.StringVar(&req.Project, "project", "", "project id")
 		f.StringVar(&permissions, "permissions", "", "permissions (comma separated values)")
 		f.Parse(args[1:])
-		req.Permissions = strings.Split(permissions, ",")
+		req.Permissions = splitComma(permissions)
 		resp, err = s.Authorized(context.Background(), &req)
 	}
 	if err != nil {
@@ -308,7 +309,7 @@ func (rn Runner) role(args ...string) error {
 		f.StringVar(&req.Name, "name", "", "role name")
 		f.StringVar(&permissions, "permissions", "", "permissions")
 		f.Parse(args[1:])
-		req.Permissions = strings.Split(permissions, ",")
+		req.Permissions = splitComma(permissions)
 		resp, err = s.Create(context.Background(), &req)
 	case "list":
 		var req api.RoleList
@@ -355,7 +356,7 @@ func (rn Runner) role(args ...string) error {
 		f.StringVar(&req.Email, "email", "", "email")
 		f.StringVar(&roles, "roles", "", "roles")
 		f.Parse(args[1:])
-		req.Roles = strings.Split(roles, ",")
+		req.Roles = splitComma(roles)
 		resp, err = s.Bind(context.Background(), &req)
 	}
 	if err != nil {
@@ -444,33 +445,7 @@ func (rn Runner) deployment(args ...string) error {
 		req.TimeRange = api.DeploymentMetricsTimeRange(timeRange)
 		resp, err = s.Metrics(context.Background(), &req)
 	case "deploy":
-		var (
-			req         api.DeploymentDeploy
-			typ         string
-			port        int
-			minReplicas int
-			maxReplicas int
-		)
-		f.StringVar(&req.Location, "location", "", "location")
-		f.StringVar(&req.Project, "project", "", "project id")
-		f.StringVar(&req.Name, "name", "", "deployment name")
-		f.StringVar(&req.Image, "image", "", "docker image")
-		f.StringVar(&typ, "type", "", "deployment type")
-		f.IntVar(&port, "port", 0, "port")
-		f.IntVar(&minReplicas, "minReplicas", 0, "autoscale min replicas")
-		f.IntVar(&maxReplicas, "maxReplicas", 0, "autoscale max replicas")
-		f.Parse(args[1:])
-		req.Type = api.ParseDeploymentTypeString(typ)
-		if port > 0 {
-			req.Port = &port
-		}
-		if minReplicas > 0 {
-			req.MinReplicas = &minReplicas
-		}
-		if maxReplicas > 0 {
-			req.MaxReplicas = &maxReplicas
-		}
-		resp, err = s.Deploy(context.Background(), &req)
+		return rn.deploymentDeploy(args[1:]...)
 	case "set":
 		return rn.deploymentSet(args[1:]...)
 	}
@@ -541,6 +516,207 @@ func (rn Runner) route(args ...string) error {
 		return err
 	}
 	return rn.print(resp)
+}
+
+func (rn Runner) deploymentDeploy(args ...string) error {
+	req, outputMode, err := parseDeploymentDeploy(args)
+	if errors.Is(err, flag.ErrHelp) {
+		return nil // usage already printed; -h is a clean exit, matching ExitOnError
+	}
+	if err != nil {
+		return err
+	}
+	rn.OutputMode = outputMode
+
+	resp, err := rn.API.Deployment().Deploy(context.Background(), &req)
+	if err != nil {
+		return err
+	}
+	return rn.print(resp)
+}
+
+// parseDeploymentDeploy maps the full api.DeploymentDeploy surface to flags. It
+// is pure (no API calls) so the flag→request mapping is unit-testable.
+//
+// The request is a merge: every optional field is left nil/empty unless its
+// flag is provided, so omitting a flag preserves the previous revision's value.
+// Scalar pointers use visitedFlags so an explicit zero/empty can be sent (e.g.
+// -ttl 0 to clear, -internal=false), while the long-standing -port/-minReplicas/
+// -maxReplicas keep their >0 semantics for backward compatibility.
+func parseDeploymentDeploy(args []string) (api.DeploymentDeploy, string, error) {
+	var (
+		req         api.DeploymentDeploy
+		outputMode  string
+		typ         string
+		port        int
+		minReplicas int
+		maxReplicas int
+
+		protocol string
+		internal bool
+
+		env             multiFlag
+		addEnv          multiFlag
+		removeEnv       string
+		envGroups       string
+		addEnvGroups    string
+		removeEnvGroups string
+
+		command string
+		cmdArgs string
+
+		workloadIdentity string
+		pullSecret       string
+		schedule         string
+		ttl              int64
+
+		diskName      string
+		diskMountPath string
+		diskSubPath   string
+
+		cpuRequest string
+		memRequest string
+		cpuLimit   string
+		memLimit   string
+
+		mountData          multiFlag
+		requireGoogleLogin bool
+		allowedEmails      string
+		allowedDomains     string
+		sidecarsFile       string
+	)
+
+	// ContinueOnError (not ExitOnError) so a parse error returns instead of
+	// calling os.Exit — keeps the function pure and testable; the caller surfaces
+	// the error. Output is discarded so the error is reported once, by main.
+	f := flag.NewFlagSet("deployment deploy", flag.ContinueOnError)
+	f.SetOutput(io.Discard)
+	f.StringVar(&outputMode, "output", "table", "output mode: table, yaml, json")
+	f.StringVar(&req.Location, "location", "", "location")
+	f.StringVar(&req.Project, "project", "", "project id")
+	f.StringVar(&req.Name, "name", "", "deployment name")
+	f.StringVar(&req.Image, "image", "", "docker image")
+	f.StringVar(&typ, "type", "", "deployment type (WebService, Worker, CronJob, TCPService, InternalTCPService, Static)")
+	f.IntVar(&port, "port", 0, "port")
+	f.IntVar(&minReplicas, "minReplicas", 0, "autoscale min replicas")
+	f.IntVar(&maxReplicas, "maxReplicas", 0, "autoscale max replicas")
+	f.StringVar(&protocol, "protocol", "", "WebService protocol: http, https, h2c")
+	f.BoolVar(&internal, "internal", false, "run WebService as an internal service")
+	f.Var(&env, "env", "env KEY=VALUE, replaces all env (repeatable)")
+	f.Var(&addEnv, "addEnv", "env KEY=VALUE to add to the previous revision (repeatable)")
+	f.StringVar(&removeEnv, "removeEnv", "", "env keys to remove (comma separated)")
+	f.StringVar(&envGroups, "envGroups", "", "env groups, replaces all (comma separated)")
+	f.StringVar(&addEnvGroups, "addEnvGroups", "", "env groups to add (comma separated)")
+	f.StringVar(&removeEnvGroups, "removeEnvGroups", "", "env groups to remove (comma separated)")
+	f.StringVar(&command, "command", "", "container entrypoint command (comma separated)")
+	f.StringVar(&cmdArgs, "args", "", "container args (comma separated)")
+	f.StringVar(&workloadIdentity, "workloadIdentity", "", "workload identity name")
+	f.StringVar(&pullSecret, "pullSecret", "", "pull secret name")
+	f.StringVar(&schedule, "schedule", "", "cron schedule (CronJob)")
+	f.Int64Var(&ttl, "ttl", 0, "seconds until auto-delete; pass 0 to clear an existing TTL")
+	f.StringVar(&diskName, "diskName", "", "disk name (Stateful)")
+	f.StringVar(&diskMountPath, "diskMountPath", "", "disk mount path")
+	f.StringVar(&diskSubPath, "diskSubPath", "", "disk sub path")
+	f.StringVar(&cpuRequest, "cpuRequest", "", "CPU request (e.g. 250m)")
+	f.StringVar(&memRequest, "memRequest", "", "memory request (e.g. 256Mi)")
+	f.StringVar(&cpuLimit, "cpuLimit", "", "CPU limit (e.g. 500m)")
+	f.StringVar(&memLimit, "memLimit", "", "memory limit (e.g. 512Mi)")
+	f.Var(&mountData, "mountData", "mounted file PATH=VALUE (repeatable)")
+	f.BoolVar(&requireGoogleLogin, "requireGoogleLogin", false, "require Google login to access the deployment")
+	f.StringVar(&allowedEmails, "allowedEmails", "", "allowed emails for access (comma separated)")
+	f.StringVar(&allowedDomains, "allowedDomains", "", "allowed domains for access (comma separated)")
+	f.StringVar(&sidecarsFile, "sidecarsFile", "", "path to a YAML/JSON file with the sidecars list")
+	if err := f.Parse(args); err != nil {
+		// -h/-help: print usage like the ExitOnError commands do, then let the
+		// caller treat it as a clean (non-error) exit.
+		if errors.Is(err, flag.ErrHelp) {
+			fmt.Fprintln(os.Stderr, "Usage: deploys deployment deploy [flags]")
+			f.SetOutput(os.Stderr)
+			f.PrintDefaults()
+		}
+		return req, "", err
+	}
+
+	set := visitedFlags(f)
+
+	req.Type = api.ParseDeploymentTypeString(typ)
+	if port > 0 {
+		req.Port = &port
+	}
+	if minReplicas > 0 {
+		req.MinReplicas = &minReplicas
+	}
+	if maxReplicas > 0 {
+		req.MaxReplicas = &maxReplicas
+	}
+	if set["protocol"] {
+		p := api.DeploymentProtocol(protocol)
+		req.Protocol = &p
+	}
+	if set["internal"] {
+		req.Internal = &internal
+	}
+	if set["workloadIdentity"] {
+		req.WorkloadIdentity = &workloadIdentity
+	}
+	if set["pullSecret"] {
+		req.PullSecret = &pullSecret
+	}
+	if set["schedule"] {
+		req.Schedule = &schedule
+	}
+	if set["ttl"] {
+		req.TTL = &ttl
+	}
+
+	var err error
+	if req.Env, err = parseKV(env); err != nil {
+		return req, "", err
+	}
+	if req.AddEnv, err = parseKV(addEnv); err != nil {
+		return req, "", err
+	}
+	if req.MountData, err = parseKV(mountData); err != nil {
+		return req, "", err
+	}
+	req.RemoveEnv = splitComma(removeEnv)
+	req.EnvGroups = splitComma(envGroups)
+	req.AddEnvGroups = splitComma(addEnvGroups)
+	req.RemoveEnvGroups = splitComma(removeEnvGroups)
+	req.Command = splitComma(command)
+	req.Args = splitComma(cmdArgs)
+
+	if diskName != "" {
+		req.Disk = &api.DeploymentDisk{
+			Name:      diskName,
+			MountPath: diskMountPath,
+			SubPath:   diskSubPath,
+		}
+	}
+	if cpuRequest != "" || memRequest != "" || cpuLimit != "" || memLimit != "" {
+		req.Resources = &api.DeploymentResource{
+			Requests: api.ResourceItem{CPU: cpuRequest, Memory: memRequest},
+			Limits:   api.ResourceItem{CPU: cpuLimit, Memory: memLimit},
+		}
+	}
+	if requireGoogleLogin || allowedEmails != "" || allowedDomains != "" {
+		req.Access = &api.DeploymentAccessConfig{
+			RequireGoogleLogin: requireGoogleLogin,
+			AllowedEmails:      splitComma(allowedEmails),
+			AllowedDomains:     splitComma(allowedDomains),
+		}
+	}
+	if sidecarsFile != "" {
+		b, err := os.ReadFile(sidecarsFile)
+		if err != nil {
+			return req, "", err
+		}
+		if err := yaml.Unmarshal(b, &req.Sidecars); err != nil {
+			return req, "", fmt.Errorf("invalid sidecars file %q: %w", sidecarsFile, err)
+		}
+	}
+
+	return req, outputMode, nil
 }
 
 func (rn Runner) deploymentSet(args ...string) error {
@@ -923,8 +1099,7 @@ func (rn Runner) github(args ...string) error {
 		if cur == nil {
 			return fmt.Errorf("github: repository link not found for repository id %d", req.RepositoryID)
 		}
-		set := map[string]bool{}
-		f.Visit(func(fl *flag.Flag) { set[fl.Name] = true })
+		set := visitedFlags(f)
 		if !set["service-account"] {
 			req.ServiceAccount = cur.ServiceAccount
 		}

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -1,0 +1,141 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/deploys-app/api"
+)
+
+// Omitted optional flags must leave their request fields nil/empty so a deploy
+// is a merge that preserves the previous revision's values.
+func TestParseDeploymentDeploy_OmittedStayNil(t *testing.T) {
+	req, out, err := parseDeploymentDeploy([]string{
+		"-project", "p", "-location", "l", "-name", "web", "-image", "img:1",
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if out != "table" {
+		t.Errorf("output = %q; want table", out)
+	}
+	if req.Project != "p" || req.Location != "l" || req.Name != "web" || req.Image != "img:1" {
+		t.Errorf("basics not mapped: %+v", req)
+	}
+	if req.Port != nil || req.MinReplicas != nil || req.MaxReplicas != nil ||
+		req.Protocol != nil || req.Internal != nil || req.WorkloadIdentity != nil ||
+		req.PullSecret != nil || req.Schedule != nil || req.TTL != nil ||
+		req.Disk != nil || req.Resources != nil || req.Access != nil {
+		t.Errorf("omitted pointers should be nil: %+v", req)
+	}
+	if req.Env != nil || req.AddEnv != nil || req.MountData != nil ||
+		req.RemoveEnv != nil || req.EnvGroups != nil || req.Command != nil || req.Args != nil {
+		t.Errorf("omitted maps/slices should be nil: %+v", req)
+	}
+	if req.Type != 0 {
+		t.Errorf("omitted type should be the zero (unset) value, got %v", req.Type)
+	}
+}
+
+// Backward compatibility: the long-standing numeric flags keep their >0 guard
+// (so -port 0 stays nil, matching the previous inline implementation).
+func TestParseDeploymentDeploy_NumericBackcompat(t *testing.T) {
+	req, _, err := parseDeploymentDeploy([]string{"-port", "8080", "-minReplicas", "1", "-maxReplicas", "5"})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if req.Port == nil || *req.Port != 8080 || req.MinReplicas == nil || *req.MinReplicas != 1 || req.MaxReplicas == nil || *req.MaxReplicas != 5 {
+		t.Errorf("numeric flags not mapped: %+v", req)
+	}
+
+	req, _, err = parseDeploymentDeploy([]string{"-port", "0"})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if req.Port != nil {
+		t.Errorf("-port 0 should stay nil (>0 guard), got %v", *req.Port)
+	}
+}
+
+// visitedFlags semantics: an explicitly-passed zero/false must be sent (so a
+// user can clear a TTL or set internal=false), while omitting keeps it nil.
+func TestParseDeploymentDeploy_VisitClears(t *testing.T) {
+	req, _, err := parseDeploymentDeploy([]string{"-ttl", "0", "-internal=false"})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if req.TTL == nil || *req.TTL != 0 {
+		t.Errorf("-ttl 0 should send a zero pointer (clear), got %v", req.TTL)
+	}
+	if req.Internal == nil || *req.Internal != false {
+		t.Errorf("-internal=false should send a false pointer, got %v", req.Internal)
+	}
+
+	req, _, _ = parseDeploymentDeploy([]string{"-ttl", "3600", "-internal"})
+	if req.TTL == nil || *req.TTL != 3600 || req.Internal == nil || *req.Internal != true {
+		t.Errorf("set ttl/internal not mapped: %+v", req)
+	}
+}
+
+func TestParseDeploymentDeploy_MapsListsAndStructs(t *testing.T) {
+	req, _, err := parseDeploymentDeploy([]string{
+		"-type", "Worker",
+		"-env", "A=1", "-env", "B=2",
+		"-addEnv", "C=3",
+		"-removeEnv", "D,E",
+		"-envGroups", "g1,g2",
+		"-command", "/bin/app",
+		"-args", "--a,--b=1",
+		"-workloadIdentity", "wi",
+		"-pullSecret", "ps",
+		"-protocol", "h2c",
+		"-diskName", "data", "-diskMountPath", "/data",
+		"-cpuRequest", "250m", "-memLimit", "512Mi",
+		"-requireGoogleLogin", "-allowedDomains", "example.com",
+		"-mountData", "/etc/cfg=hello",
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if req.Type != api.DeploymentTypeWorker {
+		t.Errorf("type = %v; want Worker", req.Type)
+	}
+	if req.Env["A"] != "1" || req.Env["B"] != "2" || req.AddEnv["C"] != "3" {
+		t.Errorf("env maps = %v / %v", req.Env, req.AddEnv)
+	}
+	if len(req.RemoveEnv) != 2 || req.RemoveEnv[0] != "D" || len(req.EnvGroups) != 2 {
+		t.Errorf("lists = %v / %v", req.RemoveEnv, req.EnvGroups)
+	}
+	if len(req.Command) != 1 || req.Command[0] != "/bin/app" || len(req.Args) != 2 || req.Args[1] != "--b=1" {
+		t.Errorf("command/args = %v / %v", req.Command, req.Args)
+	}
+	if req.WorkloadIdentity == nil || *req.WorkloadIdentity != "wi" || req.PullSecret == nil || *req.PullSecret != "ps" {
+		t.Errorf("wi/pullSecret not mapped: %+v", req)
+	}
+	if req.Protocol == nil || *req.Protocol != api.DeploymentProtocolH2C {
+		t.Errorf("protocol not mapped: %v", req.Protocol)
+	}
+	if req.Disk == nil || req.Disk.Name != "data" || req.Disk.MountPath != "/data" {
+		t.Errorf("disk not mapped: %+v", req.Disk)
+	}
+	if req.Resources == nil || req.Resources.Requests.CPU != "250m" || req.Resources.Limits.Memory != "512Mi" {
+		t.Errorf("resources not mapped: %+v", req.Resources)
+	}
+	if req.Access == nil || !req.Access.RequireGoogleLogin || len(req.Access.AllowedDomains) != 1 {
+		t.Errorf("access not mapped: %+v", req.Access)
+	}
+	if req.MountData["/etc/cfg"] != "hello" {
+		t.Errorf("mountData not mapped: %v", req.MountData)
+	}
+}
+
+func TestParseDeploymentDeploy_Errors(t *testing.T) {
+	if _, _, err := parseDeploymentDeploy([]string{"-env", "BAD"}); err == nil {
+		t.Error("invalid -env KEY=VALUE should error")
+	}
+	if _, _, err := parseDeploymentDeploy([]string{"-nope"}); err == nil {
+		t.Error("unknown flag should return an error, not exit")
+	}
+	if _, out, err := parseDeploymentDeploy([]string{"-output", "json"}); err != nil || out != "json" {
+		t.Errorf("output passthrough: out=%q err=%v", out, err)
+	}
+}


### PR DESCRIPTION
## What

`deployment deploy` only supported `image/type/port/minReplicas/maxReplicas`. This adds the **full `api.DeploymentDeploy` surface** and unifies the CLI's flag-handling on the shared helpers.

New `deploy` flags: `-protocol -internal -env -addEnv -removeEnv -envGroups -addEnvGroups -removeEnvGroups -command -args -workloadIdentity -pullSecret -schedule -ttl -diskName -diskMountPath -diskSubPath -cpuRequest -memRequest -cpuLimit -memLimit -mountData -requireGoogleLogin -allowedEmails -allowedDomains -sidecarsFile`.

## Merge semantics (don't break current behavior)

`DeploymentDeploy` is a merge: every optional field is a pointer/map/slice that stays **nil unless its flag is provided**, so omitting a flag preserves the previous revision's value.

- Scalar pointers use a shared `visitedFlags` helper so an **explicit zero/empty** is sent — `-ttl 0` clears a TTL, `-internal=false` sets false — while omitting keeps it nil.
- The long-standing `-port`/`-minReplicas`/`-maxReplicas` keep their `>0` guard, so behavior is byte-identical to the old inline `deploy` (e.g. `-port 0` stays nil).
- `image`/`name` remain required by `api`'s `Valid()` for non-static, so an image-less deploy errors client-side rather than silently wiping the image.
- The mapping lives in a **pure `parseDeploymentDeploy`** → unit-tested (omitted-stay-nil, numeric back-compat, visit-clears, maps/lists/structs, error paths).

## Same pattern applied to the rest of the CLI

- `me authorized`, `role create`, `role bind`: raw `strings.Split(x, ",")` → shared `splitComma` (trims, drops empties, `nil` on empty instead of the buggy `[""]`). Identical for clean comma input.
- `github update`: inline `f.Visit` loop → the shared `visitedFlags` helper.

## Notes

- No `api`/server change. Pin unchanged.
- Static deploys aren't exposed here (they carry a `site://` ref from the build-deploy-action, not hand-typed); `-sidecarsFile` takes a YAML/JSON file since `Sidecar` is a nested union.
- `-h` prints usage and exits 0, matching the other subcommands.

## Verification

This repo has no PR CI — verified locally: `go build ./...`, `go vet ./...`, `go test ./...` (8 pass), and CLI smoke tests (`-env BAD`, unknown flag, missing sidecars file, `-h` usage).

## Supersedes #1

This reimplements the feature from #1 (@yokeTH) in the current CLI style — using the repo's `multiFlag`/`parseKV`/`splitComma` helpers, merge-correct via `visitedFlags`, and without the Nix scaffolding / `robfig/cron` dependency that PR carried. Credited via `Co-authored-by`. Closing #1 in favor of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)