### PR TITLE
feat: add cache command and other missing CLI surface

### DIFF
--- a/internal/runner/cache.go
+++ b/internal/runner/cache.go
@@ -1,0 +1,104 @@
+package runner
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/deploys-app/api"
+	"gopkg.in/yaml.v2"
+)
+
+func (rn Runner) cache(args ...string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("invalid command")
+	}
+
+	s := rn.API.Cache()
+
+	var (
+		resp any
+		err  error
+	)
+
+	f := flag.NewFlagSet("", flag.ExitOnError)
+	rn.registerFlags(f)
+	switch args[0] {
+	default:
+		return fmt.Errorf("invalid command")
+	case "get":
+		var req api.CacheGet
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Location, "location", "", "location")
+		f.Parse(args[1:])
+		resp, err = s.Get(context.Background(), &req)
+	case "list":
+		var req api.CacheList
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.Parse(args[1:])
+		resp, err = s.List(context.Background(), &req)
+	case "set":
+		// Set replaces the whole zone (all overrides) all-or-nothing, so it takes
+		// a spec file rather than per-override flags. The file is the yaml form of
+		// `cache get` (description, overrides); project, location, and description
+		// flags override values in the file.
+		var (
+			fn          string
+			project     string
+			location    string
+			description string
+		)
+		f.StringVar(&fn, "f", "", "spec file (yaml: description, overrides)")
+		f.StringVar(&project, "project", "", "project id")
+		f.StringVar(&location, "location", "", "location")
+		f.StringVar(&description, "description", "", "zone description")
+		f.Parse(args[1:])
+
+		if fn == "" {
+			return fmt.Errorf("spec file required (-f)")
+		}
+		b, ferr := os.ReadFile(fn)
+		if ferr != nil {
+			return ferr
+		}
+		// non-strict so the yaml output of `cache get` (which carries extra
+		// read-only fields) can be edited and fed back in
+		var req api.CacheSet
+		ferr = yaml.Unmarshal(b, &req)
+		if ferr != nil {
+			return fmt.Errorf("parse %s: %w", fn, ferr)
+		}
+		if project != "" {
+			req.Project = project
+		}
+		if location != "" {
+			req.Location = location
+		}
+		if description != "" {
+			req.Description = description
+		}
+		resp, err = s.Set(context.Background(), &req)
+	case "delete":
+		var req api.CacheDelete
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Location, "location", "", "location")
+		f.Parse(args[1:])
+		resp, err = s.Delete(context.Background(), &req)
+	case "metrics":
+		var (
+			req       api.CacheMetrics
+			timeRange string
+		)
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Location, "location", "", "location")
+		f.StringVar(&timeRange, "time-range", "1h", "time range (1h, 6h, 12h, 1d, 7d, 30d)")
+		f.Parse(args[1:])
+		req.TimeRange = api.WAFMetricsTimeRange(timeRange)
+		resp, err = s.Metrics(context.Background(), &req)
+	}
+	if err != nil {
+		return err
+	}
+	return rn.print(resp)
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -118,6 +118,8 @@ func (rn Runner) Run(args ...string) error {
 		return rn.route(args[1:]...)
 	case "waf":
 		return rn.waf(args[1:]...)
+	case "cache":
+		return rn.cache(args[1:]...)
 	case "disk":
 		return rn.disk(args[1:]...)
 	case "pullsecret", "ps":
@@ -173,6 +175,11 @@ func (rn Runner) me(args ...string) error {
 		f.Parse(args[1:])
 		req.Permissions = splitComma(permissions)
 		resp, err = s.Authorized(context.Background(), &req)
+	case "permissions":
+		var req api.MePermissions
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.Parse(args[1:])
+		resp, err = s.Permissions(context.Background(), &req)
 	}
 	if err != nil {
 		return err
@@ -358,6 +365,9 @@ func (rn Runner) role(args ...string) error {
 		f.Parse(args[1:])
 		req.Roles = splitComma(roles)
 		resp, err = s.Bind(context.Background(), &req)
+	case "permissions":
+		f.Parse(args[1:])
+		resp, err = s.Permissions(context.Background(), &api.Empty{})
 	}
 	if err != nil {
 		return err
@@ -808,6 +818,18 @@ func (rn Runner) disk(args ...string) error {
 		f.StringVar(&req.Name, "name", "", "disk name")
 		f.Parse(args[1:])
 		resp, err = s.Delete(context.Background(), &req)
+	case "metrics":
+		var (
+			req       api.DiskMetrics
+			timeRange string
+		)
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Location, "location", "", "location")
+		f.StringVar(&req.Name, "name", "", "disk name")
+		f.StringVar(&timeRange, "time-range", "1h", "time range (1h, 6h, 12h, 1d, 2d, 7d, 30d)")
+		f.Parse(args[1:])
+		req.TimeRange = api.DiskMetricsTimeRange(timeRange)
+		resp, err = s.Metrics(context.Background(), &req)
 	}
 	if err != nil {
 		return err

--- a/main.go
+++ b/main.go
@@ -82,18 +82,20 @@ Usage:
   deploys <command> <subcommand> [flags]
 
 Commands:
-  me                      get, authorized
+  me                      get, authorized, permissions
   billing                 create, list, get, update, delete, report, skus, project,
                           invoices, invoice, downloadinvoice, downloadreceipt
   location                list, get
   project                 create, list, get, update, delete, usage
-  role                    create, list, get, delete, grant, revoke, users, bind
+  role                    create, list, get, delete, grant, revoke, users, bind,
+                          permissions
   deployment, deploy, d   list, get, deploy, delete, revisions, pause, resume,
                           rollback, metrics, set
   domain                  create, get, list, delete, purgecache
   route                   create, get, list, delete
   waf                     get, list, set, delete, metrics, limitmetrics
-  disk                    create, get, list, update, delete
+  cache                   get, list, set, delete, metrics
+  disk                    create, get, list, update, delete, metrics
   pullsecret, ps          create, get, list, delete
   workloadidentity, wi    create, get, list, delete
   serviceaccount, sa      create, get, list, update, delete, createkey, deletekey


### PR DESCRIPTION
## What

Audited the CLI against `api.Interface` and added the **user-facing API methods that had no command**.

| Added | API method | Notes |
|---|---|---|
| `cache` (get/list/set/delete/metrics) | `Cache.*` | **new resource** — edge cache-override zone (`cache.*` perms); mirrors `waf` |
| `disk metrics` | `Disk.Metrics` | was missing from the `disk` command |
| `role permissions` | `Role.Permissions` | list assignable permissions |
| `me permissions` | `Me.Permissions` | caller's effective permissions for a project |

`cache set` takes a `-f` spec file (YAML: `description`, `overrides`) and replaces the whole zone all-or-nothing — same UX as `waf set`.

## Not added (deliberately)

`me uploadKYCDocument` / `billing uploadTransferSlip` (multipart file-upload flows, not CLI-shaped); `Access`/`Collector`/`Deployer` are internal-secret interfaces and the remaining `github.*` methods are console/OIDC-machine flows. After this, every user-facing method has a command.

## Verification

No PR CI in this repo — verified locally: `go build ./...`, `go vet ./...`, `go test ./...` (8 pass), CLI smoke tests, and `/scrutinize` (ship). Rebased onto current `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)