### PR TITLE
Add `site publish` command and `-site` deploy flag for static web

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/deploys-app/deploys
 go 1.26
 
 require (
-	github.com/deploys-app/api v0.0.0-20260614230708-052c044d7d4f
+	github.com/deploys-app/api v0.0.0-20260615094734-cb4257ee7f3f
 	golang.org/x/oauth2 v0.14.0
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/deploys-app/deploys
 go 1.26
 
 require (
-	github.com/deploys-app/api v0.0.0-20260615094734-cb4257ee7f3f
+	github.com/deploys-app/api v0.0.0-20260615105442-6011d386f1fa
 	golang.org/x/oauth2 v0.14.0
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -9,10 +9,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:W
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deploys-app/api v0.0.0-20260612091159-6332523a9654 h1:Ucga9bk7Tl0PWeBUX0Oy6LGZNzsClHnVSQvWOTU8y+o=
-github.com/deploys-app/api v0.0.0-20260612091159-6332523a9654/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
-github.com/deploys-app/api v0.0.0-20260614230708-052c044d7d4f h1:FDPf3/YY3h1nq5nGfWR5WntMVCVCB0j3OZ6itrcTe9c=
-github.com/deploys-app/api v0.0.0-20260614230708-052c044d7d4f/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
+github.com/deploys-app/api v0.0.0-20260615094734-cb4257ee7f3f h1:LvujUh1OHfqFh7r/DQBjYTcsED6ufEaJW3FRmlcgvyY=
+github.com/deploys-app/api v0.0.0-20260615094734-cb4257ee7f3f/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:W
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deploys-app/api v0.0.0-20260615094734-cb4257ee7f3f h1:LvujUh1OHfqFh7r/DQBjYTcsED6ufEaJW3FRmlcgvyY=
-github.com/deploys-app/api v0.0.0-20260615094734-cb4257ee7f3f/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
+github.com/deploys-app/api v0.0.0-20260615105442-6011d386f1fa h1:jwptyE42+0Hg85KukmBKTrCg1NLcDHj+K0IuPNQ+V+U=
+github.com/deploys-app/api v0.0.0-20260615105442-6011d386f1fa/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -142,6 +142,8 @@ func (rn Runner) Run(args ...string) error {
 		return rn.github(args[1:]...)
 	case "collector":
 		return rn.collector(args[1:]...)
+	case "site":
+		return rn.site(args[1:]...)
 	}
 }
 
@@ -606,6 +608,7 @@ func parseDeploymentDeploy(args []string) (api.DeploymentDeploy, string, error) 
 	f.StringVar(&req.Project, "project", "", "project id")
 	f.StringVar(&req.Name, "name", "", "deployment name")
 	f.StringVar(&req.Image, "image", "", "docker image")
+	f.StringVar(&req.Site, "site", "", "static site release ref (site://...); use with -type Static (see `deploys site publish`)")
 	f.StringVar(&typ, "type", "", "deployment type (WebService, Worker, CronJob, TCPService, InternalTCPService, Static)")
 	f.IntVar(&port, "port", 0, "port")
 	f.IntVar(&minReplicas, "minReplicas", 0, "autoscale min replicas")

--- a/internal/runner/site.go
+++ b/internal/runner/site.go
@@ -1,0 +1,45 @@
+package runner
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/deploys-app/api/client"
+)
+
+// site handles `deploys site <subcommand>`. Publishing reads the local
+// filesystem and uploads via the raw-HTTP /sites/* endpoints, so it uses the
+// concrete *client.Client helper (PublishSite) rather than the api.Interface.
+func (rn Runner) site(args ...string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("invalid command")
+	}
+
+	f := flag.NewFlagSet("", flag.ExitOnError)
+	rn.registerFlags(f)
+
+	switch args[0] {
+	default:
+		return fmt.Errorf("invalid command")
+	case "publish":
+		var opts client.SitePublishOptions
+		f.StringVar(&opts.Project, "project", "", "project id")
+		f.StringVar(&opts.Name, "name", "", "deployment name")
+		f.StringVar(&opts.Dir, "dir", ".", "local directory to publish")
+		f.StringVar(&opts.Environment, "environment", "", "release environment: production (default) or pr-<n>")
+		f.BoolVar(&opts.SPA, "spa", false, "serve index.html for unmatched paths (single-page app)")
+		f.StringVar(&opts.NotFound, "notFound", "", "custom 404 document path (e.g. 404.html)")
+		f.Parse(args[1:])
+
+		c, ok := rn.API.(*client.Client)
+		if !ok {
+			return fmt.Errorf("site publish requires the default api client")
+		}
+		res, err := c.PublishSite(context.Background(), &opts)
+		if err != nil {
+			return err
+		}
+		return rn.print(res)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -106,6 +106,7 @@ Commands:
   auditlog                list
   dropbox                 list, metrics
   github                  link, unlink, update, list
+  site                    publish
 
 Flags:
   -output table|yaml|json (or -oyaml, -ojson, -otable)


### PR DESCRIPTION
## What

Adds CLI support for static-web deploys, reusing the new `client.PublishSite` helper.

- **`deploys site publish`** — uploads a local directory as a static-web release and prints the `site://…@<sha>` ref + release sha. Content-addresses files; skips blobs the server already has.
- **`-site` flag on `deployment deploy`** — previously missing, so a published release couldn't be deployed from the CLI at all.

```
deploys site publish --project p --name web --dir ./dist
deploys deployment deploy --project p --location l --name web \
    --type Static --site site://.../web@<sha>
```

Flags: `-project -name -dir(.) -environment -spa -notFound`.

## Notes

- `site publish` reads the local filesystem, so it uses the concrete `*client.Client` (type-asserted from `rn.API`), not the `api.Interface`.
- This repo has no PR CI — verified locally: `go build`/`vet`/`test` pass, and a CLI smoke (`site` dispatch, `site publish -h` flags, help listing) checks out.

## Dependencies

- Pins `github.com/deploys-app/api` to the **api#68** branch commit (`client.PublishSite`). Re-pin to `master`/`main` after api#68 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)