### PR TITLE
ci: also publish release binaries to dl.deploys.app

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,10 @@ jobs:
     - uses: actions/setup-go@v6
       with:
         go-version: "^1.26"
+    - uses: google-github-actions/auth@v3
+      with:
+        credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
+    - uses: google-github-actions/setup-gcloud@v2
     - uses: goreleaser/goreleaser-action@v7
       with:
         version: latest
@@ -20,6 +24,22 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         CGO_ENABLED: 0
+    # Publish the release archives + checksums to the public download bucket
+    # (https://dl.deploys.app), mirroring the mcp release. The tag goes to an
+    # immutable deploys/<tag>/ and is mirrored to a short-cached deploys/latest/
+    # for "always newest" download URLs.
+    - name: Upload to dl.deploys.app
+      run: |
+        shopt -s nullglob
+        files=(dist/*.tar.gz dist/*.zip dist/checksums.txt)
+        if [ ${#files[@]} -eq 0 ]; then
+          echo "no release artifacts found in dist/" >&2
+          exit 1
+        fi
+        gcloud storage cp "${files[@]}" "gs://dl.deploys.app/deploys/${GITHUB_REF_NAME}/" \
+          --cache-control="public, max-age=31536000, immutable"
+        gcloud storage cp "${files[@]}" "gs://dl.deploys.app/deploys/latest/" \
+          --cache-control="public, max-age=300"
     - uses: actions/upload-artifact@v7
       with:
         name: deploys

--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ go install github.com/deploys-app/deploys@latest
 ```
 
 **Binaries:** download the archive for your OS/arch from the
-[GitHub releases](https://github.com/deploys-app/deploys/releases).
+[GitHub releases](https://github.com/deploys-app/deploys/releases), or from the
+public bucket at `https://dl.deploys.app/deploys/` — `latest/` for the newest
+release or `<tag>/` for a specific one (e.g.
+`https://dl.deploys.app/deploys/latest/`).
 
 **Container:**
 


### PR DESCRIPTION
## Why

The CLI is released only to GitHub releases today. The mcp server already mirrors its release binaries to the public bucket `dl.deploys.app`; this gives the `deploys` CLI the same stable, no-GitHub download source (e.g. for scripted installs).

## What

In the tag-triggered `Release` workflow, after GoReleaser publishes the GitHub release, upload its archives + `checksums.txt` to `gs://dl.deploys.app/deploys/`:

- `deploys/<tag>/` — immutable (`max-age=31536000, immutable`)
- `deploys/latest/` — short-cached (`max-age=300`) mirror of the newest release

Auth reuses the existing `GOOGLE_CREDENTIALS` secret already used by the `Build` workflow (added `google-github-actions/auth` + `setup-gcloud`). The upload globs `dist/*.tar.gz dist/*.zip dist/checksums.txt` (nullglob), so it picks up whatever GoReleaser emits and fails loudly if dist/ is empty. GoReleaser and the GitHub release/artifact steps are unchanged.

README: documents the `https://dl.deploys.app/deploys/{latest,<tag>}/` download source.

## Note for the operator

The service account behind `GOOGLE_CREDENTIALS` in this repo needs object-write on the `dl.deploys.app` bucket. If it doesn't already have it (the mcp release uses a self-hosted runner / possibly a different SA), grant `roles/storage.objectAdmin` on that bucket before cutting the next tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)