### PR TITLE
Add me generate-token command

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ match the corresponding resource.
 - `get` — current user info.
 - `authorized` `-permissions a,b` — check whether you hold the given permissions in `-project`.
 - `permissions` — your effective permissions in `-project` (and whether you're an admin).
+- `generate-token` `-project -permissions a,b [-ttl 900]` — mint a short-lived bearer token scoped to `-project` and a subset of your permissions (allowed: `dropbox.upload`, `site.publish`; TTL 60–3600s, default 900). Useful for handing a narrow credential to an automated tool (e.g. to `curl` a file upload to dropbox) without exposing a full token.
 
 ### location
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/deploys-app/deploys
 go 1.26
 
 require (
-	github.com/deploys-app/api v0.0.0-20260615105442-6011d386f1fa
+	github.com/deploys-app/api v0.0.0-20260616065402-2cee526bd262
 	golang.org/x/oauth2 v0.14.0
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:W
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deploys-app/api v0.0.0-20260615105442-6011d386f1fa h1:jwptyE42+0Hg85KukmBKTrCg1NLcDHj+K0IuPNQ+V+U=
-github.com/deploys-app/api v0.0.0-20260615105442-6011d386f1fa/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
+github.com/deploys-app/api v0.0.0-20260616065402-2cee526bd262 h1:0rIVlBtoPnWWpsSF7fXVmwu3sVjQufM7evZ9PxXEFKw=
+github.com/deploys-app/api v0.0.0-20260616065402-2cee526bd262/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -182,6 +182,17 @@ func (rn Runner) me(args ...string) error {
 		f.StringVar(&req.Project, "project", "", "project id")
 		f.Parse(args[1:])
 		resp, err = s.Permissions(context.Background(), &req)
+	case "generate-token", "generateToken":
+		var (
+			req         api.MeGenerateToken
+			permissions string
+		)
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&permissions, "permissions", "", "permissions (comma separated; allowed: dropbox.upload, site.publish)")
+		f.IntVar(&req.TTLSeconds, "ttl", 0, "token lifetime in seconds (60-3600, default 900)")
+		f.Parse(args[1:])
+		req.Permissions = splitComma(permissions)
+		resp, err = s.GenerateToken(context.Background(), &req)
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
Wraps the new `me.generateToken` RPC (deploys-app/api#76, deploys-app/apiserver#140) as a CLI command.

## What

```
deploys me generate-token -project <id> -permissions dropbox.upload[,site.publish] [-ttl 900]
```

Mints a short-lived bearer token scoped to `-project` and a subset of your permissions (allowlist: `dropbox.upload`, `site.publish`; TTL 60–3600s, default 900). The token is strictly weaker than your account — useful for handing a narrow credential to an automated tool (e.g. to `curl` a file upload to dropbox) without exposing a full token. Prints `TOKEN / EXPIRES AT / PROJECT / PERMISSIONS` (or `-oyaml`/`-ojson`).

Bumps the api dependency to pick up `client.Me().GenerateToken` (`2cee526`).

## Verification

`go build` / `go vet` clean, tests pass. Smoke-tested the client-side validation:
- missing `-project` → `project required`
- `-permissions deployment.deploy` → `permission "deployment.deploy" is not allowed for generated tokens (allowed: dropbox.upload, site.publish)`

(deploys has no PR CI — verified locally.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)