### PR TITLE
ci: gitignore gha-creds so GoReleaser doesn't fail on dirty tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .idea/
 .DS_Store
+# Credentials file written into the workspace by google-github-actions/auth in
+# the release workflow. Ignoring it keeps the tree clean so GoReleaser (which
+# refuses to release a dirty git state) doesn't fail.
+gha-creds-*.json


### PR DESCRIPTION
## Problem

`v1.1.1`'s release run failed: GoReleaser aborted with `git is in a dirty state` (`?? gha-creds-<hash>.json`). The `google-github-actions/auth` step I added in #14 writes a credentials file into the workspace before GoReleaser runs, and GoReleaser refuses to release a dirty tree. No artifacts were published (it failed at git-state validation in 0s).

## Fix

Add `gha-creds-*.json` to `.gitignore` — `git status --porcelain` (what GoReleaser checks) ignores it, so the tree is clean. Order-independent and also prevents the creds file from ever being committed.

After merge, `v1.1.1` will be re-tagged at the fixed commit to re-run the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)