### PR TITLE
feat(dropbox): add `dropbox upload` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,8 @@ separate from the WAF (a role can hold `cache.*` without `waf.*`).
 ### dropbox
 
 - `list` `-after -before -limit`, `metrics` `-time-range 7d|30d|90d`.
+- `upload` `-project -file -filename -ttl`, e.g. `deploys dropbox upload -project acme -file site.tar.gz -ttl 7`.
+- `upload` reads `-file` (or stdin when omitted or `-`) and prints the public, short-lived download URL; `-ttl` is 1-7 days (default 1). Requires the `dropbox.upload` permission.
 - `-after`/`-before` accept RFC 3339 or `YYYY-MM-DD`.
 
 ### auditlog

--- a/internal/runner/dropbox.go
+++ b/internal/runner/dropbox.go
@@ -4,8 +4,12 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
 
 	"github.com/deploys-app/api"
+	"github.com/deploys-app/api/client"
 )
 
 func (rn Runner) dropbox(args ...string) error {
@@ -43,6 +47,32 @@ func (rn Runner) dropbox(args ...string) error {
 		f.Parse(args[1:])
 		req.TimeRange = api.UsageMetricsTimeRange(timeRange)
 		resp, err = s.Metrics(context.Background(), &req)
+	case "upload":
+		var opts client.DropboxUploadOptions
+		var file string
+		f.StringVar(&opts.Project, "project", "", "project id")
+		f.StringVar(&file, "file", "", "path to the file to upload, or - for stdin (default stdin)")
+		f.StringVar(&opts.Filename, "filename", "", "filename recorded in the download (defaults to the base name of -file)")
+		f.IntVar(&opts.TTLDays, "ttl", 0, "download lifetime in days, 1-7 (default 1)")
+		f.Parse(args[1:])
+
+		c, ok := rn.API.(*client.Client)
+		if !ok {
+			return fmt.Errorf("dropbox upload requires the default api client")
+		}
+
+		if file == "" || file == "-" {
+			opts.Content, err = io.ReadAll(os.Stdin)
+		} else {
+			opts.Content, err = os.ReadFile(file)
+			if opts.Filename == "" {
+				opts.Filename = filepath.Base(file)
+			}
+		}
+		if err != nil {
+			return err
+		}
+		resp, err = c.DropboxUpload(context.Background(), &opts)
 	}
 	if err != nil {
 		return err

--- a/main.go
+++ b/main.go
@@ -104,7 +104,7 @@ Commands:
                           deletemanifest, untag, metrics
   envgroup, eg            create, get, list, update, delete
   auditlog                list
-  dropbox                 list, metrics
+  dropbox                 list, metrics, upload
   github                  link, unlink, update, list
   site                    publish
 


### PR DESCRIPTION
## What

Add a `deploys dropbox upload` subcommand that uploads a file to the temporary dropbox service and prints the resulting short-lived, public download URL.

```
deploys dropbox upload -project acme -file site.tar.gz -ttl 7
```

## Why

The `client.DropboxUpload` helper already exists (api#73), but the CLI only wired `dropbox list` / `dropbox metrics`. This exposes upload so users can host a file (e.g. a static-site archive) and pass the returned URL to `site publish`.

## Details

- Reads `-file` (or stdin when omitted or `-`); defaults `-filename` to the base name of `-file`.
- Flags: `-project` (required), `-file`, `-filename`, `-ttl` (1-7 days, default 1).
- Requires the `dropbox.upload` permission.
- Uses the concrete `*client.Client` (like `site publish`) since upload is a raw-HTTP POST to `dropbox.deploys.app`, not an arpc action.
- No api dep bump needed — `master` already pins a version with the helper.
- Updated `main.go` help and README.

## Testing

`go build ./...`, `go vet ./...`, `go test ./...` all pass. Verified validation paths against the built binary (missing project → `dropbox: project required`; missing file → read error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)