### PR TITLE
deployment: add restart subcommand

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/deploys-app/deploys
 go 1.26
 
 require (
-	github.com/deploys-app/api v0.0.0-20260615105442-6011d386f1fa
+	github.com/deploys-app/api v0.0.0-20260617003501-7fb5bf092448
 	golang.org/x/oauth2 v0.14.0
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/deploys-app/api v0.0.0-20260615105442-6011d386f1fa h1:jwptyE42+0Hg85KukmBKTrCg1NLcDHj+K0IuPNQ+V+U=
 github.com/deploys-app/api v0.0.0-20260615105442-6011d386f1fa/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
+github.com/deploys-app/api v0.0.0-20260617003501-7fb5bf092448 h1:OJrGQoFGSSzHrcpqhokHRWDWpsrPyBSW5ic6bpW0j3A=
+github.com/deploys-app/api v0.0.0-20260617003501-7fb5bf092448/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -436,6 +436,13 @@ func (rn Runner) deployment(args ...string) error {
 		f.StringVar(&req.Name, "name", "", "deployment name")
 		f.Parse(args[1:])
 		resp, err = s.Resume(context.Background(), &req)
+	case "restart":
+		var req api.DeploymentRestart
+		f.StringVar(&req.Location, "location", "", "location")
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Name, "name", "", "deployment name")
+		f.Parse(args[1:])
+		resp, err = s.Restart(context.Background(), &req)
 	case "rollback":
 		var req api.DeploymentRollback
 		f.StringVar(&req.Location, "location", "", "location")

--- a/main.go
+++ b/main.go
@@ -90,7 +90,7 @@ Commands:
   role                    create, list, get, delete, grant, revoke, users, bind,
                           permissions
   deployment, deploy, d   list, get, deploy, delete, revisions, pause, resume,
-                          rollback, metrics, set
+                          restart, rollback, metrics, set
   domain                  create, get, list, delete, purgecache
   route                   create, get, list, delete
   waf                     get, list, set, delete, metrics, limitmetrics


### PR DESCRIPTION
## What

Add `deploys deployment restart --project --location --name`, which re-rolls the deployment's current revision to recreate the pods (via the new `deployment.restart` API, deploys-app/api#78). Bumps the api dep and updates the command help/listing.

## Verification

`go build ./...` + `go vet` + `go test ./...` (8 passed). (This repo has no PR CI; verified locally.) Depends on deploys-app/apiserver#143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)