### PR TITLE
ci: nightly image on master, tag+latest image on release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,4 +34,4 @@ jobs:
         tags: |
           asia-southeast1-docker.pkg.dev/deploys-app/public/cli:${{ github.sha }}
           registry.deploys.app/public/deploys-cli:${{ github.sha }}
-          registry.deploys.app/public/deploys-cli:latest
+          registry.deploys.app/public/deploys-cli:nightly

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,11 +9,21 @@ jobs:
     name: Build
     steps:
     - uses: actions/checkout@v6
+    - uses: google-github-actions/auth@v3
+      id: auth
+      with:
+        credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
+        token_format: access_token
+    - uses: docker/login-action@v4
+      with:
+        registry: asia-southeast1-docker.pkg.dev
+        username: oauth2accesstoken
+        password: ${{ steps.auth.outputs.access_token }}
     - uses: docker/login-action@v4
       with:
         registry: registry.deploys.app
-        username: ${{ secrets.REGISTRY_USERNAME }}
-        password: ${{ secrets.REGISTRY_PASSWORD }}
+        username: oauth2accesstoken
+        password: ${{ steps.auth.outputs.access_token }}
     - uses: docker/setup-buildx-action@v4
       with:
         version: latest
@@ -22,5 +32,6 @@ jobs:
         provenance: false
         push: true
         tags: |
+          asia-southeast1-docker.pkg.dev/deploys-app/public/cli:${{ github.sha }}
           registry.deploys.app/public/deploys-cli:${{ github.sha }}
           registry.deploys.app/public/deploys-cli:latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,16 +9,11 @@ jobs:
     name: Build
     steps:
     - uses: actions/checkout@v6
-    - uses: google-github-actions/auth@v3
-      id: auth
-      with:
-        credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
-        token_format: access_token
     - uses: docker/login-action@v4
       with:
-        registry: asia-southeast1-docker.pkg.dev
-        username: oauth2accesstoken
-        password: ${{ steps.auth.outputs.access_token }}
+        registry: registry.deploys.app
+        username: ${{ secrets.REGISTRY_USERNAME }}
+        password: ${{ secrets.REGISTRY_PASSWORD }}
     - uses: docker/setup-buildx-action@v4
       with:
         version: latest
@@ -26,4 +21,6 @@ jobs:
       with:
         provenance: false
         push: true
-        tags: asia-southeast1-docker.pkg.dev/deploys-app/public/cli:${{ github.sha }}
+        tags: |
+          registry.deploys.app/public/deploys-cli:${{ github.sha }}
+          registry.deploys.app/public/deploys-cli:latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,9 +17,40 @@ jobs:
       with:
         go-version: "^1.26"
     - uses: google-github-actions/auth@v3
+      id: auth
       with:
         credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
+        token_format: access_token
     - uses: google-github-actions/setup-gcloud@v2
+    # Tagged release -> build and push the container image to both registries,
+    # tagged with the release tag and `latest`. Master builds publish the rolling
+    # `nightly` image from the Build workflow instead.
+    - if: github.ref_type == 'tag'
+      uses: docker/login-action@v4
+      with:
+        registry: asia-southeast1-docker.pkg.dev
+        username: oauth2accesstoken
+        password: ${{ steps.auth.outputs.access_token }}
+    - if: github.ref_type == 'tag'
+      uses: docker/login-action@v4
+      with:
+        registry: registry.deploys.app
+        username: oauth2accesstoken
+        password: ${{ steps.auth.outputs.access_token }}
+    - if: github.ref_type == 'tag'
+      uses: docker/setup-buildx-action@v4
+      with:
+        version: latest
+    - if: github.ref_type == 'tag'
+      uses: docker/build-push-action@v7
+      with:
+        provenance: false
+        push: true
+        tags: |
+          asia-southeast1-docker.pkg.dev/deploys-app/public/cli:${{ github.ref_name }}
+          asia-southeast1-docker.pkg.dev/deploys-app/public/cli:latest
+          registry.deploys.app/public/deploys-cli:${{ github.ref_name }}
+          registry.deploys.app/public/deploys-cli:latest
     # Tagged push -> full release (publishes the GitHub release).
     # master push -> --snapshot build (no tag required, nothing published by
     # goreleaser); the nightly artifacts are uploaded and released below.

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ release or `<tag>/` for a specific one (e.g.
 docker run --rm -e DEPLOYS_TOKEN registry.deploys.app/public/deploys-cli <command>...
 ```
 
-`latest` tracks the newest `master` build; pin a specific build with its
-commit-sha tag (`registry.deploys.app/public/deploys-cli:<sha>`).
+Image tags: `latest` is the newest tagged release, `<tag>` (e.g. `v1.2.3`) pins a
+specific release, and `nightly` tracks the newest `master` build.
 
 ## Authentication
 
@@ -258,6 +258,9 @@ go vet ./...
 go test ./...
 ```
 
-Releases are cut by GoReleaser on tag push; the container image is built by the
-`Build` workflow on `master` and pushed to
-`registry.deploys.app/public/deploys-cli` (tags: the commit sha and `latest`).
+Releases are cut by GoReleaser on tag push. The container image is built and
+pushed to `registry.deploys.app/public/deploys-cli` (mirrored to
+`asia-southeast1-docker.pkg.dev/deploys-app/public/cli`) by:
+
+- the `Release` workflow on a tag — tagged with the release tag and `latest`;
+- the `Build` workflow on `master` — tagged with the commit sha and `nightly`.

--- a/README.md
+++ b/README.md
@@ -24,8 +24,11 @@ release or `<tag>/` for a specific one (e.g.
 **Container:**
 
 ```bash
-docker run --rm -e DEPLOYS_TOKEN asia-southeast1-docker.pkg.dev/deploys-app/public/cli <command>...
+docker run --rm -e DEPLOYS_TOKEN registry.deploys.app/public/deploys-cli <command>...
 ```
+
+`latest` tracks the newest `master` build; pin a specific build with its
+commit-sha tag (`registry.deploys.app/public/deploys-cli:<sha>`).
 
 ## Authentication
 
@@ -255,5 +258,6 @@ go vet ./...
 go test ./...
 ```
 
-Releases are cut by GoReleaser on tag push; the container image is built and
-pushed by the `Build` workflow on `master`.
+Releases are cut by GoReleaser on tag push; the container image is built by the
+`Build` workflow on `master` and pushed to
+`registry.deploys.app/public/deploys-cli` (tags: the commit sha and `latest`).


### PR DESCRIPTION
## What

Split the CLI container image tags by trigger, across both registries (`registry.deploys.app/public/deploys-cli` and the kept `asia-southeast1-docker.pkg.dev/deploys-app/public/cli`):

| Trigger | Workflow | Tags pushed |
|---------|----------|-------------|
| `master` push | **Build** | `registry.deploys.app/public/deploys-cli`: `nightly`, `<sha>` · AR `public/cli`: `<sha>` |
| tag push | **Release** | both images: `<tag>` and `latest` |

So `latest` = newest tagged release, `<tag>` = a specific release, `nightly` = newest `master` build.

## How

- `registry.deploys.app` accepts the same Google `oauth2accesstoken`, so the Release job adds `token_format: access_token` to the existing `GOOGLE_CREDENTIALS` auth and `docker login`s both registries — **no new secrets**.
- The Release docker steps are gated `if: github.ref_type == 'tag'`, so a `master` run of Release skips them (the nightly image comes from Build); `Build` only triggers on `master`, so tags don't double-build.
- README updated: container-run uses `registry.deploys.app/public/deploys-cli` and documents the `latest` / `<tag>` / `nightly` tag meanings.

`release.yaml`'s GoReleaser binaries + `dl.deploys.app` upload are unchanged. Both workflow YAMLs validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)