### PR TITLE
ci: fix registry.deploys.app push auth + run docker after release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,6 +14,11 @@ jobs:
       with:
         credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
         token_format: access_token
+        # cloud-platform: push to the Artifact Registry host. userinfo.email:
+        # registry.deploys.app forwards the token to api.deploys.app/me.get,
+        # which resolves the caller's email from the token — without this scope
+        # it can't, and the push is rejected as unauthorized.
+        access_token_scopes: https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/userinfo.email
     - uses: docker/login-action@v4
       with:
         registry: asia-southeast1-docker.pkg.dev

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,36 +21,12 @@ jobs:
       with:
         credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
         token_format: access_token
+        # cloud-platform: Artifact Registry + the dl.deploys.app bucket.
+        # userinfo.email: registry.deploys.app forwards the token to
+        # api.deploys.app/me.get, which resolves the caller's email from it —
+        # without this scope it can't, and the image push is unauthorized.
+        access_token_scopes: https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/userinfo.email
     - uses: google-github-actions/setup-gcloud@v2
-    # Tagged release -> build and push the container image to both registries,
-    # tagged with the release tag and `latest`. Master builds publish the rolling
-    # `nightly` image from the Build workflow instead.
-    - if: github.ref_type == 'tag'
-      uses: docker/login-action@v4
-      with:
-        registry: asia-southeast1-docker.pkg.dev
-        username: oauth2accesstoken
-        password: ${{ steps.auth.outputs.access_token }}
-    - if: github.ref_type == 'tag'
-      uses: docker/login-action@v4
-      with:
-        registry: registry.deploys.app
-        username: oauth2accesstoken
-        password: ${{ steps.auth.outputs.access_token }}
-    - if: github.ref_type == 'tag'
-      uses: docker/setup-buildx-action@v4
-      with:
-        version: latest
-    - if: github.ref_type == 'tag'
-      uses: docker/build-push-action@v7
-      with:
-        provenance: false
-        push: true
-        tags: |
-          asia-southeast1-docker.pkg.dev/deploys-app/public/cli:${{ github.ref_name }}
-          asia-southeast1-docker.pkg.dev/deploys-app/public/cli:latest
-          registry.deploys.app/public/deploys-cli:${{ github.ref_name }}
-          registry.deploys.app/public/deploys-cli:latest
     # Tagged push -> full release (publishes the GitHub release).
     # master push -> --snapshot build (no tag required, nothing published by
     # goreleaser); the nightly artifacts are uploaded and released below.
@@ -100,3 +76,33 @@ jobs:
         path: dist/*
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # Tagged release -> build and push the container image to both registries,
+    # tagged with the release tag and `latest`. Master builds publish the rolling
+    # `nightly` image from the Build workflow instead. Runs LAST so an image-push
+    # hiccup can never block publishing the release above.
+    - if: github.ref_type == 'tag'
+      uses: docker/login-action@v4
+      with:
+        registry: asia-southeast1-docker.pkg.dev
+        username: oauth2accesstoken
+        password: ${{ steps.auth.outputs.access_token }}
+    - if: github.ref_type == 'tag'
+      uses: docker/login-action@v4
+      with:
+        registry: registry.deploys.app
+        username: oauth2accesstoken
+        password: ${{ steps.auth.outputs.access_token }}
+    - if: github.ref_type == 'tag'
+      uses: docker/setup-buildx-action@v4
+      with:
+        version: latest
+    - if: github.ref_type == 'tag'
+      uses: docker/build-push-action@v7
+      with:
+        provenance: false
+        push: true
+        tags: |
+          asia-southeast1-docker.pkg.dev/deploys-app/public/cli:${{ github.ref_name }}
+          asia-southeast1-docker.pkg.dev/deploys-app/public/cli:latest
+          registry.deploys.app/public/deploys-cli:${{ github.ref_name }}
+          registry.deploys.app/public/deploys-cli:latest


### PR DESCRIPTION
## What

Fixes the `registry.deploys.app/public/deploys-cli` push, which failed with `unauthorized: authentication required` (broke the v1.1.2 release before GoReleaser ran).

**Root cause:** `registry.deploys.app` (the `registry/` service) forwards the docker Basic credentials to `api.deploys.app/me.get` to resolve the caller's identity. The access token minted by `google-github-actions/auth` defaults to the `cloud-platform` scope only, so `me.get` couldn't resolve an email → unauthorized. (The Artifact Registry host accepts the token fine because it only needs `cloud-platform`.)

**Fix:** request `userinfo.email` **in addition to** `cloud-platform` via `access_token_scopes` (keeping `cloud-platform` for the AR host + the `dl.deploys.app` bucket). No new secrets — the Google SA still authenticates both registries.

## Also

Moved the Release workflow's docker build/push to run **after** GoReleaser + the bucket upload, so an image-push hiccup can never block publishing the GitHub release/binaries again.

YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)