### PR TITLE
chore: modernize to Go 1.26 idioms

### DIFF
--- a/internal/runner/flags.go
+++ b/internal/runner/flags.go
@@ -73,7 +73,7 @@ func (f timeFlag) Set(v string) error {
 // Returns nil on empty input.
 func splitComma(s string) []string {
 	var res []string
-	for _, x := range strings.Split(s, ",") {
+	for x := range strings.SplitSeq(s, ",") {
 		x = strings.TrimSpace(x)
 		if x != "" {
 			res = append(res, x)


### PR DESCRIPTION
## What

Behavior-preserving modernization, applied with the official `modernize` analyzer from `golang.org/x/tools` (version-aware against this module's `go` directive).

### Changes
- Use `strings.SplitSeq` instead of `strings.Split` for split-and-iterate in `splitComma` (Go 1.24)

### Safety
- **No functional change.**
- `go build`, `go vet`, and `go test ./...` all pass. (This repo has no PR CI; verified locally.)
- `omitempty`→`omitzero` JSON-tag rewrites were deliberately excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)