### PR TITLE
Implement --help for all commands and subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,12 @@ Point the CLI at a non-production API with `DEPLOYS_ENDPOINT`.
 deploys <command> <subcommand> [flags]
 ```
 
-Run `deploys` with no arguments for the top-level help, or any command with `-h`
-to see its flags.
+Help is available at every level (via `-h`, `--help`, or `help`):
+
+- `deploys` (or `deploys help`) — the top-level command list.
+- `deploys <command> -h` — a command's subcommands, e.g. `deploys deployment -h`.
+- `deploys <command> <subcommand> -h` — a subcommand's flags, e.g.
+  `deploys deployment deploy -h`.
 
 ### Output formats
 

--- a/internal/runner/auditlog.go
+++ b/internal/runner/auditlog.go
@@ -2,15 +2,14 @@ package runner
 
 import (
 	"context"
-	"flag"
 	"fmt"
 
 	"github.com/deploys-app/api"
 )
 
 func (rn Runner) auditLog(args ...string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("invalid command")
+	if len(args) == 0 || IsHelpArg(args[0]) {
+		return rn.groupUsage("auditlog")
 	}
 
 	s := rn.API.AuditLog()
@@ -20,11 +19,10 @@ func (rn Runner) auditLog(args ...string) error {
 		err  error
 	)
 
-	f := flag.NewFlagSet("", flag.ExitOnError)
-	rn.registerFlags(f)
+	f := rn.subFlagSet("auditlog", args[0])
 	switch args[0] {
 	default:
-		return fmt.Errorf("invalid command")
+		return rn.unknownSub("auditlog", args[0])
 	case "list":
 		var (
 			req     api.AuditLogList

--- a/internal/runner/billing.go
+++ b/internal/runner/billing.go
@@ -2,15 +2,13 @@ package runner
 
 import (
 	"context"
-	"flag"
-	"fmt"
 
 	"github.com/deploys-app/api"
 )
 
 func (rn Runner) billing(args ...string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("invalid command")
+	if len(args) == 0 || IsHelpArg(args[0]) {
+		return rn.groupUsage("billing")
 	}
 
 	s := rn.API.Billing()
@@ -20,11 +18,10 @@ func (rn Runner) billing(args ...string) error {
 		err  error
 	)
 
-	f := flag.NewFlagSet("", flag.ExitOnError)
-	rn.registerFlags(f)
+	f := rn.subFlagSet("billing", args[0])
 	switch args[0] {
 	default:
-		return fmt.Errorf("invalid command")
+		return rn.unknownSub("billing", args[0])
 	case "create":
 		var req api.BillingCreate
 		f.StringVar(&req.Name, "name", "", "billing account name")

--- a/internal/runner/cache.go
+++ b/internal/runner/cache.go
@@ -2,7 +2,6 @@ package runner
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"os"
 
@@ -11,8 +10,8 @@ import (
 )
 
 func (rn Runner) cache(args ...string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("invalid command")
+	if len(args) == 0 || IsHelpArg(args[0]) {
+		return rn.groupUsage("cache")
 	}
 
 	s := rn.API.Cache()
@@ -22,11 +21,10 @@ func (rn Runner) cache(args ...string) error {
 		err  error
 	)
 
-	f := flag.NewFlagSet("", flag.ExitOnError)
-	rn.registerFlags(f)
+	f := rn.subFlagSet("cache", args[0])
 	switch args[0] {
 	default:
-		return fmt.Errorf("invalid command")
+		return rn.unknownSub("cache", args[0])
 	case "get":
 		var req api.CacheGet
 		f.StringVar(&req.Project, "project", "", "project id")

--- a/internal/runner/domain.go
+++ b/internal/runner/domain.go
@@ -2,15 +2,13 @@ package runner
 
 import (
 	"context"
-	"flag"
-	"fmt"
 
 	"github.com/deploys-app/api"
 )
 
 func (rn Runner) domain(args ...string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("invalid command")
+	if len(args) == 0 || IsHelpArg(args[0]) {
+		return rn.groupUsage("domain")
 	}
 
 	s := rn.API.Domain()
@@ -20,11 +18,10 @@ func (rn Runner) domain(args ...string) error {
 		err  error
 	)
 
-	f := flag.NewFlagSet("", flag.ExitOnError)
-	rn.registerFlags(f)
+	f := rn.subFlagSet("domain", args[0])
 	switch args[0] {
 	default:
-		return fmt.Errorf("invalid command")
+		return rn.unknownSub("domain", args[0])
 	case "create":
 		var req api.DomainCreate
 		f.StringVar(&req.Project, "project", "", "project id")

--- a/internal/runner/dropbox.go
+++ b/internal/runner/dropbox.go
@@ -2,7 +2,6 @@ package runner
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -13,8 +12,8 @@ import (
 )
 
 func (rn Runner) dropbox(args ...string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("invalid command")
+	if len(args) == 0 || IsHelpArg(args[0]) {
+		return rn.groupUsage("dropbox")
 	}
 
 	s := rn.API.Dropbox()
@@ -24,11 +23,10 @@ func (rn Runner) dropbox(args ...string) error {
 		err  error
 	)
 
-	f := flag.NewFlagSet("", flag.ExitOnError)
-	rn.registerFlags(f)
+	f := rn.subFlagSet("dropbox", args[0])
 	switch args[0] {
 	default:
-		return fmt.Errorf("invalid command")
+		return rn.unknownSub("dropbox", args[0])
 	case "list":
 		var req api.DropboxList
 		f.StringVar(&req.Project, "project", "", "project id")

--- a/internal/runner/email.go
+++ b/internal/runner/email.go
@@ -2,7 +2,6 @@ package runner
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"os"
 
@@ -10,8 +9,8 @@ import (
 )
 
 func (rn Runner) email(args ...string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("invalid command")
+	if len(args) == 0 || IsHelpArg(args[0]) {
+		return rn.groupUsage("email")
 	}
 
 	s := rn.API.Email()
@@ -21,11 +20,10 @@ func (rn Runner) email(args ...string) error {
 		err  error
 	)
 
-	f := flag.NewFlagSet("", flag.ExitOnError)
-	rn.registerFlags(f)
+	f := rn.subFlagSet("email", args[0])
 	switch args[0] {
 	default:
-		return fmt.Errorf("invalid command")
+		return rn.unknownSub("email", args[0])
 	case "send":
 		var (
 			req         api.EmailSend

--- a/internal/runner/envgroup.go
+++ b/internal/runner/envgroup.go
@@ -2,15 +2,13 @@ package runner
 
 import (
 	"context"
-	"flag"
-	"fmt"
 
 	"github.com/deploys-app/api"
 )
 
 func (rn Runner) envGroup(args ...string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("invalid command")
+	if len(args) == 0 || IsHelpArg(args[0]) {
+		return rn.groupUsage("envgroup")
 	}
 
 	s := rn.API.EnvGroup()
@@ -20,11 +18,10 @@ func (rn Runner) envGroup(args ...string) error {
 		err  error
 	)
 
-	f := flag.NewFlagSet("", flag.ExitOnError)
-	rn.registerFlags(f)
+	f := rn.subFlagSet("envgroup", args[0])
 	switch args[0] {
 	default:
-		return fmt.Errorf("invalid command")
+		return rn.unknownSub("envgroup", args[0])
 	case "create":
 		var (
 			req api.EnvGroupCreate

--- a/internal/runner/help.go
+++ b/internal/runner/help.go
@@ -1,0 +1,446 @@
+package runner
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+)
+
+// IsHelpArg reports whether s requests help instead of naming a command. It
+// covers the word "help" and the -h/-help/--help flag spellings, so help works
+// the same at every level (top, group, and subcommand).
+func IsHelpArg(s string) bool {
+	switch s {
+	case "help", "-h", "-help", "--help":
+		return true
+	}
+	return false
+}
+
+// command describes a top-level command group for help output. The registry
+// below is the single source of truth for `deploys help`, `deploys <group>
+// help`, and each subcommand's usage banner, so the three stay in sync.
+type command struct {
+	name    string
+	aliases []string
+	short   string
+	subs    []subcommand
+}
+
+// subcommand describes one leaf command. args is an optional positional/flag
+// hint shown in the usage line; hidden keeps an entry out of the group listing
+// while still feeding its description to the subcommand banner (e.g. the
+// internal "set image" leaf, listed to users as "set").
+type subcommand struct {
+	name    string
+	aliases []string
+	args    string
+	short   string
+	hidden  bool
+}
+
+// commands is the full CLI surface, in the order shown by the top-level help.
+//
+// INVARIANT: this must mirror the dispatch switches (Run in runner.go for the
+// groups, and each group method's `switch args[0]` for the leaves). Adding a
+// subcommand means adding both a `case` and an entry here; otherwise its -h
+// banner renders without a description. TestRegistryDescriptions guards that
+// every listed entry is described, but it cannot see a `case` that was never
+// listed — keep them in sync by hand.
+var commands = []command{
+	{
+		name:  "me",
+		short: "identity and access for the current credential",
+		subs: []subcommand{
+			{name: "get", short: "show the current authenticated identity"},
+			{name: "authorized", args: "-project p -permissions a,b", short: "check whether you hold the given permissions in a project"},
+			{name: "permissions", args: "-project p", short: "list your effective permissions in a project"},
+			{name: "generate-token", aliases: []string{"generateToken"}, args: "-project p -permissions a,b [-ttl 900]", short: "mint a short-lived, scope-limited bearer token"},
+		},
+	},
+	{
+		name:  "billing",
+		short: "billing accounts, reports, and invoices",
+		subs: []subcommand{
+			{name: "create", short: "create a billing account"},
+			{name: "list", short: "list billing accounts"},
+			{name: "get", args: "-id <id>", short: "show a billing account"},
+			{name: "update", args: "-id <id>", short: "update a billing account"},
+			{name: "delete", args: "-id <id>", short: "delete a billing account"},
+			{name: "report", args: "-id <id> -range <r> [-projects a,b]", short: "usage/cost report for a billing account"},
+			{name: "skus", short: "list billable SKUs and their prices"},
+			{name: "project", args: "-project p", short: "show a project's billing account"},
+			{name: "invoices", args: "-id <id>", short: "list invoices for a billing account"},
+			{name: "invoice", args: "-id <invoice id>", short: "show an invoice"},
+			{name: "downloadinvoice", args: "-id <invoice id>", short: "download an invoice PDF"},
+			{name: "downloadreceipt", args: "-id <invoice id>", short: "download a receipt PDF"},
+		},
+	},
+	{
+		name:  "location",
+		short: "available deployment locations",
+		subs: []subcommand{
+			{name: "list", short: "list available locations"},
+			{name: "get", args: "-id <id>", short: "show a location"},
+		},
+	},
+	{
+		name:  "project",
+		short: "projects, the top-level container for resources",
+		subs: []subcommand{
+			{name: "create", args: "-id -name -billingaccount", short: "create a project"},
+			{name: "list", short: "list your projects"},
+			{name: "get", short: "show a project"},
+			{name: "update", args: "[-name] [-billingaccount]", short: "update a project's name or billing account"},
+			{name: "delete", short: "delete a project"},
+			{name: "usage", short: "show a project's resource usage"},
+		},
+	},
+	{
+		name:  "role",
+		short: "custom roles and role bindings (IAM)",
+		subs: []subcommand{
+			{name: "create", args: "-role -name -permissions a,b", short: "create a custom role"},
+			{name: "list", short: "list roles"},
+			{name: "get", args: "-role", short: "show a role"},
+			{name: "delete", args: "-role", short: "delete a role"},
+			{name: "grant", args: "-role -email", short: "grant a role to a user"},
+			{name: "revoke", args: "-role -email", short: "revoke a role from a user"},
+			{name: "users", short: "list users and their roles"},
+			{name: "bind", args: "-email -roles a,b", short: "set a user's roles"},
+			{name: "permissions", short: "list every assignable permission"},
+		},
+	},
+	{
+		name:    "deployment",
+		aliases: []string{"deploy", "d"},
+		short:   "deployments and their lifecycle",
+		subs: []subcommand{
+			{name: "list", short: "list deployments"},
+			{name: "get", args: "[-revision n]", short: "show a deployment (optionally a specific revision)"},
+			{name: "deploy", short: "create or update a deployment (a merge over the previous revision)"},
+			{name: "delete", short: "delete a deployment"},
+			{name: "revisions", short: "list a deployment's revisions"},
+			{name: "pause", short: "pause a deployment"},
+			{name: "resume", short: "resume a paused deployment"},
+			{name: "restart", short: "restart a deployment"},
+			{name: "rollback", args: "-revision n", short: "roll back to a previous revision"},
+			{name: "metrics", args: "[-time-range 1h|6h|12h|1d]", short: "show deployment metrics"},
+			// "set" is the user-facing listing; "set image" is the hidden leaf that
+			// backs its banner. They share wording so the listing and banner agree.
+			{name: "set", short: "roll out a new image (set image <name> -image <ref>)"},
+			{name: "set image", args: "<name> -image <ref>", short: "roll out a new image for a deployment", hidden: true},
+		},
+	},
+	{
+		name:  "domain",
+		short: "custom domains and edge cache",
+		subs: []subcommand{
+			{name: "create", args: "-domain [-wildcard]", short: "create a custom domain"},
+			{name: "get", args: "-domain", short: "show a domain"},
+			{name: "list", short: "list domains"},
+			{name: "delete", args: "-domain", short: "delete a domain"},
+			{name: "purgecache", args: "-domain (-file <path> | -prefix <path>)", short: "purge edge cache for a domain"},
+		},
+	},
+	{
+		name:  "route",
+		short: "HTTP routes mapping a domain/path to a target",
+		subs: []subcommand{
+			{name: "create", args: "-domain -path (-target <t> | -deployment <name>)", short: "create a route"},
+			{name: "get", args: "-domain -path", short: "show a route"},
+			{name: "list", short: "list routes"},
+			{name: "delete", args: "-domain -path", short: "delete a route"},
+		},
+	},
+	{
+		name:  "waf",
+		short: "web application firewall zones",
+		subs: []subcommand{
+			{name: "get", short: "show the WAF zone"},
+			{name: "list", short: "list WAF zones in a project"},
+			{name: "set", args: "-f <spec.yaml> [-description]", short: "apply a WAF zone from a YAML spec"},
+			{name: "delete", short: "delete the WAF zone"},
+			{name: "metrics", args: "[-time-range 1h|6h|12h|1d|7d|30d]", short: "show WAF request metrics"},
+			{name: "limitmetrics", args: "[-time-range 1h|6h|12h|1d|7d|30d]", short: "show WAF rate-limit metrics"},
+		},
+	},
+	{
+		name:  "cache",
+		short: "edge cache-override zones (separate from the WAF)",
+		subs: []subcommand{
+			{name: "get", short: "show the cache-override zone"},
+			{name: "list", short: "list cache zones in a project"},
+			{name: "set", args: "-f <spec.yaml> [-description]", short: "replace the cache zone's overrides from a YAML spec"},
+			{name: "delete", short: "delete the cache zone"},
+			{name: "metrics", args: "[-time-range 1h|6h|12h|1d|7d|30d]", short: "show edge cache metrics"},
+		},
+	},
+	{
+		name:  "disk",
+		short: "persistent disks for stateful deployments",
+		subs: []subcommand{
+			{name: "create", args: "-size <Gi>", short: "create a disk"},
+			{name: "get", short: "show a disk"},
+			{name: "list", short: "list disks"},
+			{name: "update", args: "-size <Gi>", short: "resize a disk"},
+			{name: "delete", short: "delete a disk"},
+			{name: "metrics", args: "[-time-range 1h|6h|12h|1d|2d|7d|30d]", short: "show disk usage metrics"},
+		},
+	},
+	{
+		name:    "pullsecret",
+		aliases: []string{"ps"},
+		short:   "private-registry pull secrets",
+		subs: []subcommand{
+			{name: "create", args: "-server -username -password", short: "create a pull secret"},
+			{name: "get", short: "show a pull secret"},
+			{name: "list", short: "list pull secrets"},
+			{name: "delete", short: "delete a pull secret"},
+		},
+	},
+	{
+		name:    "workloadidentity",
+		aliases: []string{"wi"},
+		short:   "workload identities bound to a Google service account",
+		subs: []subcommand{
+			{name: "create", args: "-gsa <google-sa>", short: "create a workload identity"},
+			{name: "get", short: "show a workload identity"},
+			{name: "list", short: "list workload identities"},
+			{name: "delete", short: "delete a workload identity"},
+		},
+	},
+	{
+		name:    "serviceaccount",
+		aliases: []string{"sa"},
+		short:   "service accounts and their keys",
+		subs: []subcommand{
+			{name: "create", args: "-id -name -description", short: "create a service account"},
+			{name: "list", short: "list service accounts"},
+			{name: "get", args: "-id", short: "show a service account"},
+			{name: "update", args: "-id [-name -description]", short: "update a service account"},
+			{name: "delete", args: "-id", short: "delete a service account"},
+			{name: "createkey", args: "-id", short: "create a service-account key"},
+			{name: "deletekey", args: "-id -secret", short: "delete a service-account key"},
+		},
+	},
+	{
+		name:  "email",
+		short: "send transactional email and list sent messages",
+		subs: []subcommand{
+			{name: "send", args: "-from -to a,b -subject -type text|html (-content | -content-file)", short: "send an email"},
+			{name: "list", short: "list sent emails"},
+		},
+	},
+	{
+		name:  "registry",
+		short: "container image registry",
+		subs: []subcommand{
+			{name: "list", short: "list repositories"},
+			{name: "get", args: "-repository", short: "show a repository"},
+			{name: "tags", args: "-repository", short: "list a repository's tags"},
+			{name: "manifests", args: "-repository", short: "list a repository's manifests"},
+			{name: "storage", short: "show registry storage usage"},
+			{name: "delete", args: "-repository", short: "delete a repository"},
+			{name: "deletemanifest", args: "-repository -digest", short: "delete a manifest by digest"},
+			{name: "untag", args: "-repository -tag", short: "remove a tag"},
+			{name: "metrics", args: "[-time-range 7d|30d|90d]", short: "show registry storage metrics"},
+		},
+	},
+	{
+		name:    "envgroup",
+		aliases: []string{"eg"},
+		short:   "reusable environment-variable groups",
+		subs: []subcommand{
+			{name: "create", args: "-name -env KEY=VAL", short: "create an env group"},
+			{name: "get", args: "-name", short: "show an env group"},
+			{name: "list", short: "list env groups"},
+			{name: "update", args: "-name [-env|-add-env|-remove-env]", short: "update an env group's variables"},
+			{name: "delete", args: "-name", short: "delete an env group"},
+		},
+	},
+	{
+		name:  "auditlog",
+		short: "query the project audit log",
+		subs: []subcommand{
+			{name: "list", args: "[-resource-type -actor -outcome -after -before -limit]", short: "list audit-log entries"},
+		},
+	},
+	{
+		name:  "dropbox",
+		short: "short-lived file uploads (dropbox)",
+		subs: []subcommand{
+			{name: "list", args: "[-after -before -limit]", short: "list dropbox files"},
+			{name: "metrics", args: "[-time-range 7d|30d|90d]", short: "show dropbox usage metrics"},
+			{name: "upload", args: "-file <path> [-filename -ttl]", short: "upload a file and print a short-lived download URL"},
+		},
+	},
+	{
+		name:  "github",
+		short: "link GitHub repositories for build-and-deploy",
+		subs: []subcommand{
+			{name: "link", args: "-repository owner/name -service-account <sid> [-trigger -production-branch]", short: "link a GitHub repository"},
+			{name: "unlink", args: "-repository owner/name | -repository-id <id>", short: "unlink a GitHub repository"},
+			{name: "update", args: "-repository owner/name [-service-account -trigger -production-branch]", short: "change a linked repository's settings"},
+			{name: "list", short: "list linked repositories"},
+		},
+	},
+	{
+		name:  "site",
+		short: "publish static sites from the local filesystem",
+		subs: []subcommand{
+			{name: "publish", args: "-name -dir <path> [-environment -spa -notFound]", short: "publish a static site from a local directory"},
+		},
+	},
+}
+
+// lookupCommand finds a group by its canonical name or any alias.
+func lookupCommand(name string) *command {
+	for i := range commands {
+		if commands[i].name == name {
+			return &commands[i]
+		}
+		for _, a := range commands[i].aliases {
+			if a == name {
+				return &commands[i]
+			}
+		}
+	}
+	return nil
+}
+
+// lookupSub finds a leaf by its name or alias within a group.
+func (c *command) lookupSub(name string) *subcommand {
+	if c == nil {
+		return nil
+	}
+	for i := range c.subs {
+		if c.subs[i].name == name {
+			return &c.subs[i]
+		}
+		for _, a := range c.subs[i].aliases {
+			if a == name {
+				return &c.subs[i]
+			}
+		}
+	}
+	return nil
+}
+
+// PrintUsage writes the top-level help: every command group with the names of
+// its subcommands, the global flags, and the auth environment variables.
+func PrintUsage(w io.Writer) {
+	fmt.Fprint(w, "deploys.app cli\n\n")
+	fmt.Fprint(w, "Usage:\n  deploys <command> <subcommand> [flags]\n\n")
+
+	fmt.Fprintln(w, "Commands:")
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	for _, c := range commands {
+		name := c.name
+		if len(c.aliases) > 0 {
+			name += ", " + strings.Join(c.aliases, ", ")
+		}
+		var subs []string
+		for _, s := range c.subs {
+			if s.hidden {
+				continue
+			}
+			subs = append(subs, s.name)
+		}
+		fmt.Fprintf(tw, "  %s\t%s\n", name, strings.Join(subs, ", "))
+	}
+	tw.Flush()
+
+	fmt.Fprint(w, "\nFlags:\n")
+	fmt.Fprint(w, "  -output table|yaml|json   output mode (or the -oyaml, -ojson, -otable shorthands)\n")
+
+	fmt.Fprint(w, "\nEnvironment:\n")
+	tw = tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprint(tw, "  DEPLOYS_TOKEN\tbearer api token\n")
+	fmt.Fprint(tw, "  DEPLOYS_AUTH_USER\tservice-account email (basic auth, with DEPLOYS_AUTH_PASS)\n")
+	fmt.Fprint(tw, "  DEPLOYS_AUTH_PASS\tservice-account key secret\n")
+	fmt.Fprint(tw, "  DEPLOYS_ENDPOINT\toverride the api endpoint\n")
+	tw.Flush()
+
+	fmt.Fprint(w, "\nRun \"deploys <command> -h\" for a command's subcommands and flags.\n")
+}
+
+// writeGroupUsage writes a group's help: its description, aliases, and the list
+// of subcommands with one-line descriptions.
+func writeGroupUsage(w io.Writer, c *command) {
+	fmt.Fprintf(w, "%s — %s\n\n", c.name, c.short)
+	fmt.Fprintf(w, "Usage:\n  deploys %s <subcommand> [flags]\n", c.name)
+	if len(c.aliases) > 0 {
+		fmt.Fprintf(w, "\nAliases: %s\n", strings.Join(c.aliases, ", "))
+	}
+
+	fmt.Fprint(w, "\nSubcommands:\n")
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	for _, s := range c.subs {
+		if s.hidden {
+			continue
+		}
+		fmt.Fprintf(tw, "  %s\t%s\n", s.name, s.short)
+	}
+	tw.Flush()
+
+	fmt.Fprintf(w, "\nRun \"deploys %s <subcommand> -h\" for a subcommand's flags.\n", c.name)
+}
+
+// writeSubUsage writes a leaf command's help: its description, a usage line, and
+// the flag list (rendered from the live flag set, so it always matches what the
+// command actually accepts).
+func writeSubUsage(w io.Writer, f *flag.FlagSet, group, sub string) {
+	c := lookupCommand(group)
+	entry := c.lookupSub(sub)
+
+	if entry != nil && entry.short != "" {
+		fmt.Fprintf(w, "%s\n\n", entry.short)
+	}
+
+	usage := "Usage: deploys " + group + " " + sub
+	if entry != nil && entry.args != "" {
+		usage += " " + entry.args
+	}
+	usage += " [flags]"
+	fmt.Fprintf(w, "%s\n\nFlags:\n", usage)
+
+	f.SetOutput(w)
+	f.PrintDefaults()
+}
+
+// topUsage prints the top-level help.
+func (rn Runner) topUsage() error {
+	PrintUsage(rn.output())
+	return nil
+}
+
+// groupUsage prints a group's help. group is always a canonical name passed by
+// the dispatcher, so the lookup never misses.
+func (rn Runner) groupUsage(group string) error {
+	c := lookupCommand(group)
+	if c == nil {
+		return rn.topUsage()
+	}
+	writeGroupUsage(rn.output(), c)
+	return nil
+}
+
+// unknownSub reports an unrecognized subcommand and points at the group help.
+func (rn Runner) unknownSub(group, sub string) error {
+	return fmt.Errorf("deploys %s: unknown subcommand %q (run \"deploys %s -h\")", group, sub, group)
+}
+
+// subFlagSet builds the flag set for a leaf command: a named, ExitOnError set
+// that prints writeSubUsage on -h/-help/--help. registerFlags binds the shared
+// -output flag to this same Runner so the chosen output mode reaches print();
+// a pointer receiver keeps that binding pointing at the caller's Runner.
+func (rn *Runner) subFlagSet(group, sub string) *flag.FlagSet {
+	f := flag.NewFlagSet("deploys "+group+" "+sub, flag.ExitOnError)
+	f.SetOutput(rn.output())
+	rn.registerFlags(f)
+	f.Usage = func() { writeSubUsage(rn.output(), f, group, sub) }
+	return f
+}

--- a/internal/runner/help_test.go
+++ b/internal/runner/help_test.go
@@ -1,0 +1,208 @@
+package runner
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestIsHelpArg(t *testing.T) {
+	for _, s := range []string{"help", "-h", "-help", "--help"} {
+		if !IsHelpArg(s) {
+			t.Errorf("IsHelpArg(%q) = false; want true", s)
+		}
+	}
+	for _, s := range []string{"", "get", "h", "halp", "-help-me", "list"} {
+		if IsHelpArg(s) {
+			t.Errorf("IsHelpArg(%q) = true; want false", s)
+		}
+	}
+}
+
+// subFlagSet must bind the shared -output flag to the SAME Runner whose print()
+// later renders the response, otherwise -output/-ojson/-oyaml are silently
+// ignored. This guards against the binding leaking into a value-receiver copy.
+func TestSubFlagSetBindsOutputMode(t *testing.T) {
+	rn := Runner{Output: os.Stdout}
+	f := rn.subFlagSet("project", "list")
+	if err := f.Parse([]string{"-output", "json"}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if rn.OutputMode != "json" {
+		t.Fatalf("OutputMode = %q; want json (output flag not bound to the caller's Runner)", rn.OutputMode)
+	}
+}
+
+func TestLookupCommand(t *testing.T) {
+	if c := lookupCommand("deployment"); c == nil || c.name != "deployment" {
+		t.Fatalf("lookupCommand(deployment) = %v", c)
+	}
+	// aliases resolve to the canonical group
+	for _, alias := range []string{"deploy", "d"} {
+		if c := lookupCommand(alias); c == nil || c.name != "deployment" {
+			t.Errorf("lookupCommand(%q) did not resolve to deployment: %v", alias, c)
+		}
+	}
+	if c := lookupCommand("nope"); c != nil {
+		t.Errorf("lookupCommand(nope) = %v; want nil", c)
+	}
+}
+
+func TestLookupSubAlias(t *testing.T) {
+	me := lookupCommand("me")
+	if me == nil {
+		t.Fatal("me group missing")
+	}
+	// generate-token is also reachable by its camelCase alias
+	if s := me.lookupSub("generateToken"); s == nil || s.name != "generate-token" {
+		t.Errorf("lookupSub(generateToken) = %v; want generate-token", s)
+	}
+	// the hidden "set image" leaf feeds the banner but is excluded from listings
+	dep := lookupCommand("deployment")
+	if s := dep.lookupSub("set image"); s == nil || !s.hidden {
+		t.Errorf("lookupSub(set image) = %v; want a hidden entry", s)
+	}
+}
+
+func TestWriteSubUsage(t *testing.T) {
+	rn := Runner{Output: os.Stdout}
+	f := rn.subFlagSet("me", "generate-token")
+	f.String("ttl", "", "token lifetime")
+
+	var buf bytes.Buffer
+	writeSubUsage(&buf, f, "me", "generate-token")
+	out := buf.String()
+
+	for _, want := range []string{
+		"mint a short-lived",               // the short description
+		"Usage: deploys me generate-token", // the usage line with the args hint
+		"-output",                          // a flag from the live set
+		"-ttl",                             // a case-specific flag
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("writeSubUsage output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintUsageListsEveryGroup(t *testing.T) {
+	var buf bytes.Buffer
+	PrintUsage(&buf)
+	out := buf.String()
+	for _, c := range commands {
+		if !strings.Contains(out, c.name) {
+			t.Errorf("top-level usage missing group %q", c.name)
+		}
+	}
+	// hidden leaves must not surface in the top-level subcommand listing
+	if strings.Contains(out, "set image") {
+		t.Errorf("top-level usage should not list the hidden \"set image\" leaf:\n%s", out)
+	}
+}
+
+// Help at the top and group levels must render without touching the API (so a
+// nil API never panics) and without returning an error.
+func TestRunHelpNeedsNoAPI(t *testing.T) {
+	tmp, err := os.CreateTemp(t.TempDir(), "help")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tmp.Close()
+
+	cases := []struct {
+		args     []string
+		contains string
+	}{
+		{nil, "deploys.app cli"},
+		{[]string{"help"}, "deploys.app cli"},
+		{[]string{"-h"}, "deploys.app cli"},
+		{[]string{"--help"}, "deploys.app cli"},
+		{[]string{"me"}, "Subcommands:"},
+		{[]string{"me", "help"}, "identity and access"},
+		{[]string{"d", "-h"}, "deployments and their lifecycle"},
+	}
+	for _, tc := range cases {
+		if err := tmp.Truncate(0); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tmp.Seek(0, 0); err != nil {
+			t.Fatal(err)
+		}
+		rn := Runner{Output: tmp} // API intentionally nil
+		if err := rn.Run(tc.args...); err != nil {
+			t.Errorf("Run(%v) error: %v", tc.args, err)
+			continue
+		}
+		b, _ := os.ReadFile(tmp.Name())
+		if !strings.Contains(string(b), tc.contains) {
+			t.Errorf("Run(%v) output missing %q:\n%s", tc.args, tc.contains, b)
+		}
+	}
+}
+
+func TestRunUnknownCommand(t *testing.T) {
+	rn := Runner{Output: os.Stdout}
+	if err := rn.Run("definitelynotacommand"); err == nil {
+		t.Error("unknown top-level command should return an error")
+	}
+}
+
+// Every registry entry must carry a description and resolve by its name and
+// aliases, so no -h banner or listing renders blank. This guards the registry's
+// internal consistency; it cannot see a dispatch `case` that was never listed
+// (see the INVARIANT comment on commands).
+func TestRegistryDescriptions(t *testing.T) {
+	for _, c := range commands {
+		if c.name == "" || c.short == "" {
+			t.Errorf("group %q has an empty name or short", c.name)
+		}
+		if lookupCommand(c.name) != &commands[indexOf(c.name)] {
+			t.Errorf("group %q does not resolve to itself", c.name)
+		}
+		for _, a := range c.aliases {
+			if lookupCommand(a) == nil {
+				t.Errorf("group %q alias %q does not resolve", c.name, a)
+			}
+		}
+		for _, s := range c.subs {
+			if s.name == "" || s.short == "" {
+				t.Errorf("group %q sub %q has an empty name or short", c.name, s.name)
+			}
+			if c.lookupSub(s.name) == nil {
+				t.Errorf("group %q sub %q does not resolve by name", c.name, s.name)
+			}
+			for _, a := range s.aliases {
+				if c.lookupSub(a) == nil {
+					t.Errorf("group %q sub %q alias %q does not resolve", c.name, s.name, a)
+				}
+			}
+		}
+	}
+}
+
+func indexOf(group string) int {
+	for i := range commands {
+		if commands[i].name == group {
+			return i
+		}
+	}
+	return -1
+}
+
+// The deploy banner is the one help path that goes through a free function
+// rather than subFlagSet; it must still honor the injected writer (Runner.Output
+// in production) instead of writing to a hardcoded stream.
+func TestDeployHelpHonorsWriter(t *testing.T) {
+	var buf bytes.Buffer
+	_, _, err := parseDeploymentDeploy(&buf, []string{"-h"})
+	if err == nil {
+		t.Fatal("expected flag.ErrHelp for -h")
+	}
+	out := buf.String()
+	for _, want := range []string{"create or update a deployment", "Usage: deploys deployment deploy", "-image"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("deploy -h banner missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/internal/runner/registry.go
+++ b/internal/runner/registry.go
@@ -2,15 +2,13 @@ package runner
 
 import (
 	"context"
-	"flag"
-	"fmt"
 
 	"github.com/deploys-app/api"
 )
 
 func (rn Runner) registry(args ...string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("invalid command")
+	if len(args) == 0 || IsHelpArg(args[0]) {
+		return rn.groupUsage("registry")
 	}
 
 	s := rn.API.Registry()
@@ -20,11 +18,10 @@ func (rn Runner) registry(args ...string) error {
 		err  error
 	)
 
-	f := flag.NewFlagSet("", flag.ExitOnError)
-	rn.registerFlags(f)
+	f := rn.subFlagSet("registry", args[0])
 	switch args[0] {
 	default:
-		return fmt.Errorf("invalid command")
+		return rn.unknownSub("registry", args[0])
 	case "list":
 		var req api.RegistryList
 		f.StringVar(&req.Project, "project", "", "project id")

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -91,15 +91,15 @@ func (rn *Runner) replaceShortFlag(args []string) {
 }
 
 func (rn Runner) Run(args ...string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("invalid command: (empty args)")
+	if len(args) == 0 || IsHelpArg(args[0]) {
+		return rn.topUsage()
 	}
 
 	rn.replaceShortFlag(args)
 
 	switch args[0] {
 	default:
-		return fmt.Errorf("invalid command: '%s'", args[0])
+		return fmt.Errorf("invalid command: %q (run \"deploys help\")", args[0])
 	case "me":
 		return rn.me(args[1:]...)
 	case "billing":
@@ -148,8 +148,8 @@ func (rn Runner) Run(args ...string) error {
 }
 
 func (rn Runner) me(args ...string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("invalid command")
+	if len(args) == 0 || IsHelpArg(args[0]) {
+		return rn.groupUsage("me")
 	}
 
 	s := rn.API.Me()
@@ -159,11 +159,10 @@ func (rn Runner) me(args ...string) error {
 		err  error
 	)
 
-	f := flag.NewFlagSet("", flag.ExitOnError)
-	rn.registerFlags(f)
+	f := rn.subFlagSet("me", args[0])
 	switch args[0] {
 	default:
-		return fmt.Errorf("invalid command")
+		return rn.unknownSub("me", args[0])
 	case "get":
 		f.Parse(args[1:])
 		resp, err = s.Get(context.Background(), &api.Empty{})
@@ -201,8 +200,8 @@ func (rn Runner) me(args ...string) error {
 }
 
 func (rn Runner) location(args ...string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("invalid command")
+	if len(args) == 0 || IsHelpArg(args[0]) {
+		return rn.groupUsage("location")
 	}
 
 	s := rn.API.Location()
@@ -212,11 +211,10 @@ func (rn Runner) location(args ...string) error {
 		err  error
 	)
 
-	f := flag.NewFlagSet("", flag.ExitOnError)
-	rn.registerFlags(f)
+	f := rn.subFlagSet("location", args[0])
 	switch args[0] {
 	default:
-		return fmt.Errorf("invalid command")
+		return rn.unknownSub("location", args[0])
 	case "list":
 		var req api.LocationList
 		f.StringVar(&req.Project, "project", "", "project id")
@@ -235,8 +233,8 @@ func (rn Runner) location(args ...string) error {
 }
 
 func (rn Runner) project(args ...string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("invalid command")
+	if len(args) == 0 || IsHelpArg(args[0]) {
+		return rn.groupUsage("project")
 	}
 
 	s := rn.API.Project()
@@ -246,11 +244,10 @@ func (rn Runner) project(args ...string) error {
 		err  error
 	)
 
-	f := flag.NewFlagSet("", flag.ExitOnError)
-	rn.registerFlags(f)
+	f := rn.subFlagSet("project", args[0])
 	switch args[0] {
 	default:
-		return fmt.Errorf("invalid command")
+		return rn.unknownSub("project", args[0])
 	case "create":
 		var req api.ProjectCreate
 		f.StringVar(&req.SID, "id", "", "project id")
@@ -303,8 +300,8 @@ func (rn Runner) project(args ...string) error {
 }
 
 func (rn Runner) role(args ...string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("invalid command")
+	if len(args) == 0 || IsHelpArg(args[0]) {
+		return rn.groupUsage("role")
 	}
 
 	s := rn.API.Role()
@@ -314,11 +311,10 @@ func (rn Runner) role(args ...string) error {
 		err  error
 	)
 
-	f := flag.NewFlagSet("", flag.ExitOnError)
-	rn.registerFlags(f)
+	f := rn.subFlagSet("role", args[0])
 	switch args[0] {
 	default:
-		return fmt.Errorf("invalid command")
+		return rn.unknownSub("role", args[0])
 	case "create":
 		var (
 			req         api.RoleCreate
@@ -389,8 +385,17 @@ func (rn Runner) role(args ...string) error {
 }
 
 func (rn Runner) deployment(args ...string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("invalid deployment command: (empty args)")
+	if len(args) == 0 || IsHelpArg(args[0]) {
+		return rn.groupUsage("deployment")
+	}
+
+	// deploy and set own their flag handling (including -h); the shared
+	// subFlagSet below is only for the simple lifecycle subcommands.
+	switch args[0] {
+	case "deploy":
+		return rn.deploymentDeploy(args[1:]...)
+	case "set":
+		return rn.deploymentSet(args[1:]...)
 	}
 
 	s := rn.API.Deployment()
@@ -400,11 +405,10 @@ func (rn Runner) deployment(args ...string) error {
 		err  error
 	)
 
-	f := flag.NewFlagSet("", flag.ExitOnError)
-	rn.registerFlags(f)
+	f := rn.subFlagSet("deployment", args[0])
 	switch args[0] {
 	default:
-		return fmt.Errorf("invalid deployment command: '%s'", args[0])
+		return rn.unknownSub("deployment", args[0])
 	case "list":
 		var req api.DeploymentList
 		f.StringVar(&req.Location, "location", "", "location")
@@ -474,10 +478,6 @@ func (rn Runner) deployment(args ...string) error {
 		f.Parse(args[1:])
 		req.TimeRange = api.DeploymentMetricsTimeRange(timeRange)
 		resp, err = s.Metrics(context.Background(), &req)
-	case "deploy":
-		return rn.deploymentDeploy(args[1:]...)
-	case "set":
-		return rn.deploymentSet(args[1:]...)
 	}
 	if err != nil {
 		return err
@@ -486,8 +486,8 @@ func (rn Runner) deployment(args ...string) error {
 }
 
 func (rn Runner) route(args ...string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("invalid command")
+	if len(args) == 0 || IsHelpArg(args[0]) {
+		return rn.groupUsage("route")
 	}
 
 	s := rn.API.Route()
@@ -497,11 +497,10 @@ func (rn Runner) route(args ...string) error {
 		err  error
 	)
 
-	f := flag.NewFlagSet("", flag.ExitOnError)
-	rn.registerFlags(f)
+	f := rn.subFlagSet("route", args[0])
 	switch args[0] {
 	default:
-		return fmt.Errorf("invalid command")
+		return rn.unknownSub("route", args[0])
 	case "list":
 		var req api.RouteList
 		f.StringVar(&req.Project, "project", "", "project id")
@@ -549,7 +548,9 @@ func (rn Runner) route(args ...string) error {
 }
 
 func (rn Runner) deploymentDeploy(args ...string) error {
-	req, outputMode, err := parseDeploymentDeploy(args)
+	// Pass the runner's output so the -h banner honors Runner.Output like every
+	// other subcommand (subFlagSet's Usage targets rn.output()).
+	req, outputMode, err := parseDeploymentDeploy(rn.output(), args)
 	if errors.Is(err, flag.ErrHelp) {
 		return nil // usage already printed; -h is a clean exit, matching ExitOnError
 	}
@@ -573,7 +574,10 @@ func (rn Runner) deploymentDeploy(args ...string) error {
 // Scalar pointers use visitedFlags so an explicit zero/empty can be sent (e.g.
 // -ttl 0 to clear, -internal=false), while the long-standing -port/-minReplicas/
 // -maxReplicas keep their >0 semantics for backward compatibility.
-func parseDeploymentDeploy(args []string) (api.DeploymentDeploy, string, error) {
+//
+// helpOut receives the -h/-help banner (so it can be redirected and asserted in
+// tests); all other output is discarded and surfaced to the caller as an error.
+func parseDeploymentDeploy(helpOut io.Writer, args []string) (api.DeploymentDeploy, string, error) {
 	var (
 		req         api.DeploymentDeploy
 		outputMode  string
@@ -658,12 +662,11 @@ func parseDeploymentDeploy(args []string) (api.DeploymentDeploy, string, error) 
 	f.StringVar(&allowedDomains, "allowedDomains", "", "allowed domains for access (comma separated)")
 	f.StringVar(&sidecarsFile, "sidecarsFile", "", "path to a YAML/JSON file with the sidecars list")
 	if err := f.Parse(args); err != nil {
-		// -h/-help: print usage like the ExitOnError commands do, then let the
-		// caller treat it as a clean (non-error) exit.
+		// -h/-help: render the same banner as the other subcommands, then let
+		// the caller treat it as a clean (non-error) exit. Other parse errors
+		// stay quiet here (output is discarded) and are surfaced by the caller.
 		if errors.Is(err, flag.ErrHelp) {
-			fmt.Fprintln(os.Stderr, "Usage: deploys deployment deploy [flags]")
-			f.SetOutput(os.Stderr)
-			f.PrintDefaults()
+			writeSubUsage(helpOut, f, "deployment", "deploy")
 		}
 		return req, "", err
 	}
@@ -751,44 +754,45 @@ func parseDeploymentDeploy(args []string) (api.DeploymentDeploy, string, error) 
 }
 
 func (rn Runner) deploymentSet(args ...string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("invalid command")
-	}
-
-	s := rn.API.Deployment()
-
-	var (
-		resp any
-		err  error
-	)
-
-	f := flag.NewFlagSet("", flag.ExitOnError)
-	rn.registerFlags(f)
-	switch args[0] {
-	default:
-		return fmt.Errorf("invalid command")
-	case "image":
-		if len(args) == 1 {
-			return fmt.Errorf("deployment name requied")
-		}
-
-		var req api.DeploymentDeploy
-		req.Name = args[1]
+	// set currently has a single leaf, `image`; its flag set doubles as the
+	// help banner for `set`, `set -h`, and `set image -h`.
+	newImageFlags := func() (*flag.FlagSet, *api.DeploymentDeploy) {
+		req := &api.DeploymentDeploy{}
+		f := rn.subFlagSet("deployment", "set image")
 		f.StringVar(&req.Location, "location", "", "location")
 		f.StringVar(&req.Project, "project", "", "project id")
 		f.StringVar(&req.Image, "image", "", "deployment image")
+		return f, req
+	}
+
+	if len(args) == 0 || IsHelpArg(args[0]) {
+		f, _ := newImageFlags()
+		f.Usage()
+		return nil
+	}
+
+	switch args[0] {
+	default:
+		return rn.unknownSub("deployment set", args[0])
+	case "image":
+		f, req := newImageFlags()
+		if len(args) < 2 || IsHelpArg(args[1]) {
+			f.Usage()
+			return nil
+		}
+		req.Name = args[1]
 		f.Parse(args[2:])
-		resp, err = s.Deploy(context.Background(), &req)
+		resp, err := rn.API.Deployment().Deploy(context.Background(), req)
+		if err != nil {
+			return err
+		}
+		return rn.print(resp)
 	}
-	if err != nil {
-		return err
-	}
-	return rn.print(resp)
 }
 
 func (rn Runner) disk(args ...string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("invalid command")
+	if len(args) == 0 || IsHelpArg(args[0]) {
+		return rn.groupUsage("disk")
 	}
 
 	s := rn.API.Disk()
@@ -798,11 +802,10 @@ func (rn Runner) disk(args ...string) error {
 		err  error
 	)
 
-	f := flag.NewFlagSet("", flag.ExitOnError)
-	rn.registerFlags(f)
+	f := rn.subFlagSet("disk", args[0])
 	switch args[0] {
 	default:
-		return fmt.Errorf("invalid command")
+		return rn.unknownSub("disk", args[0])
 	case "create":
 		var req api.DiskCreate
 		f.StringVar(&req.Project, "project", "", "project id")
@@ -859,8 +862,8 @@ func (rn Runner) disk(args ...string) error {
 }
 
 func (rn Runner) pullSecret(args ...string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("invalid command")
+	if len(args) == 0 || IsHelpArg(args[0]) {
+		return rn.groupUsage("pullsecret")
 	}
 
 	s := rn.API.PullSecret()
@@ -870,11 +873,10 @@ func (rn Runner) pullSecret(args ...string) error {
 		err  error
 	)
 
-	f := flag.NewFlagSet("", flag.ExitOnError)
-	rn.registerFlags(f)
+	f := rn.subFlagSet("pullsecret", args[0])
 	switch args[0] {
 	default:
-		return fmt.Errorf("invalid command")
+		return rn.unknownSub("pullsecret", args[0])
 	case "create":
 		var req api.PullSecretCreate
 		f.StringVar(&req.Location, "location", "", "location")
@@ -913,8 +915,8 @@ func (rn Runner) pullSecret(args ...string) error {
 }
 
 func (rn Runner) workloadIdentity(args ...string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("invalid command")
+	if len(args) == 0 || IsHelpArg(args[0]) {
+		return rn.groupUsage("workloadidentity")
 	}
 
 	s := rn.API.WorkloadIdentity()
@@ -924,11 +926,10 @@ func (rn Runner) workloadIdentity(args ...string) error {
 		err  error
 	)
 
-	f := flag.NewFlagSet("", flag.ExitOnError)
-	rn.registerFlags(f)
+	f := rn.subFlagSet("workloadidentity", args[0])
 	switch args[0] {
 	default:
-		return fmt.Errorf("invalid command")
+		return rn.unknownSub("workloadidentity", args[0])
 	case "create":
 		var req api.WorkloadIdentityCreate
 		f.StringVar(&req.Project, "project", "", "project id")
@@ -965,8 +966,8 @@ func (rn Runner) workloadIdentity(args ...string) error {
 }
 
 func (rn Runner) serviceAccount(args ...string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("invalid command")
+	if len(args) == 0 || IsHelpArg(args[0]) {
+		return rn.groupUsage("serviceaccount")
 	}
 
 	s := rn.API.ServiceAccount()
@@ -976,11 +977,10 @@ func (rn Runner) serviceAccount(args ...string) error {
 		err  error
 	)
 
-	f := flag.NewFlagSet("", flag.ExitOnError)
-	rn.registerFlags(f)
+	f := rn.subFlagSet("serviceaccount", args[0])
 	switch args[0] {
 	default:
-		return fmt.Errorf("invalid command")
+		return rn.unknownSub("serviceaccount", args[0])
 	case "create":
 		var req api.ServiceAccountCreate
 		f.StringVar(&req.Project, "project", "", "project id")
@@ -1035,8 +1035,8 @@ func (rn Runner) serviceAccount(args ...string) error {
 }
 
 func (rn Runner) github(args ...string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("invalid command")
+	if len(args) == 0 || IsHelpArg(args[0]) {
+		return rn.groupUsage("github")
 	}
 
 	s := rn.API.GitHub()
@@ -1046,11 +1046,10 @@ func (rn Runner) github(args ...string) error {
 		err  error
 	)
 
-	f := flag.NewFlagSet("", flag.ExitOnError)
-	rn.registerFlags(f)
+	f := rn.subFlagSet("github", args[0])
 	switch args[0] {
 	default:
-		return fmt.Errorf("invalid command")
+		return rn.unknownSub("github", args[0])
 	case "link":
 		var (
 			req        api.GitHubLink

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"io"
 	"testing"
 
 	"github.com/deploys-app/api"
@@ -9,7 +10,7 @@ import (
 // Omitted optional flags must leave their request fields nil/empty so a deploy
 // is a merge that preserves the previous revision's values.
 func TestParseDeploymentDeploy_OmittedStayNil(t *testing.T) {
-	req, out, err := parseDeploymentDeploy([]string{
+	req, out, err := parseDeploymentDeploy(io.Discard, []string{
 		"-project", "p", "-location", "l", "-name", "web", "-image", "img:1",
 	})
 	if err != nil {
@@ -39,7 +40,7 @@ func TestParseDeploymentDeploy_OmittedStayNil(t *testing.T) {
 // Backward compatibility: the long-standing numeric flags keep their >0 guard
 // (so -port 0 stays nil, matching the previous inline implementation).
 func TestParseDeploymentDeploy_NumericBackcompat(t *testing.T) {
-	req, _, err := parseDeploymentDeploy([]string{"-port", "8080", "-minReplicas", "1", "-maxReplicas", "5"})
+	req, _, err := parseDeploymentDeploy(io.Discard, []string{"-port", "8080", "-minReplicas", "1", "-maxReplicas", "5"})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -47,7 +48,7 @@ func TestParseDeploymentDeploy_NumericBackcompat(t *testing.T) {
 		t.Errorf("numeric flags not mapped: %+v", req)
 	}
 
-	req, _, err = parseDeploymentDeploy([]string{"-port", "0"})
+	req, _, err = parseDeploymentDeploy(io.Discard, []string{"-port", "0"})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -59,7 +60,7 @@ func TestParseDeploymentDeploy_NumericBackcompat(t *testing.T) {
 // visitedFlags semantics: an explicitly-passed zero/false must be sent (so a
 // user can clear a TTL or set internal=false), while omitting keeps it nil.
 func TestParseDeploymentDeploy_VisitClears(t *testing.T) {
-	req, _, err := parseDeploymentDeploy([]string{"-ttl", "0", "-internal=false"})
+	req, _, err := parseDeploymentDeploy(io.Discard, []string{"-ttl", "0", "-internal=false"})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -70,14 +71,14 @@ func TestParseDeploymentDeploy_VisitClears(t *testing.T) {
 		t.Errorf("-internal=false should send a false pointer, got %v", req.Internal)
 	}
 
-	req, _, _ = parseDeploymentDeploy([]string{"-ttl", "3600", "-internal"})
+	req, _, _ = parseDeploymentDeploy(io.Discard, []string{"-ttl", "3600", "-internal"})
 	if req.TTL == nil || *req.TTL != 3600 || req.Internal == nil || *req.Internal != true {
 		t.Errorf("set ttl/internal not mapped: %+v", req)
 	}
 }
 
 func TestParseDeploymentDeploy_MapsListsAndStructs(t *testing.T) {
-	req, _, err := parseDeploymentDeploy([]string{
+	req, _, err := parseDeploymentDeploy(io.Discard, []string{
 		"-type", "Worker",
 		"-env", "A=1", "-env", "B=2",
 		"-addEnv", "C=3",
@@ -129,13 +130,13 @@ func TestParseDeploymentDeploy_MapsListsAndStructs(t *testing.T) {
 }
 
 func TestParseDeploymentDeploy_Errors(t *testing.T) {
-	if _, _, err := parseDeploymentDeploy([]string{"-env", "BAD"}); err == nil {
+	if _, _, err := parseDeploymentDeploy(io.Discard, []string{"-env", "BAD"}); err == nil {
 		t.Error("invalid -env KEY=VALUE should error")
 	}
-	if _, _, err := parseDeploymentDeploy([]string{"-nope"}); err == nil {
+	if _, _, err := parseDeploymentDeploy(io.Discard, []string{"-nope"}); err == nil {
 		t.Error("unknown flag should return an error, not exit")
 	}
-	if _, out, err := parseDeploymentDeploy([]string{"-output", "json"}); err != nil || out != "json" {
+	if _, out, err := parseDeploymentDeploy(io.Discard, []string{"-output", "json"}); err != nil || out != "json" {
 		t.Errorf("output passthrough: out=%q err=%v", out, err)
 	}
 }

--- a/internal/runner/site.go
+++ b/internal/runner/site.go
@@ -2,7 +2,6 @@ package runner
 
 import (
 	"context"
-	"flag"
 	"fmt"
 
 	"github.com/deploys-app/api/client"
@@ -12,16 +11,15 @@ import (
 // filesystem and uploads via the raw-HTTP /sites/* endpoints, so it uses the
 // concrete *client.Client helper (PublishSite) rather than the api.Interface.
 func (rn Runner) site(args ...string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("invalid command")
+	if len(args) == 0 || IsHelpArg(args[0]) {
+		return rn.groupUsage("site")
 	}
 
-	f := flag.NewFlagSet("", flag.ExitOnError)
-	rn.registerFlags(f)
+	f := rn.subFlagSet("site", args[0])
 
 	switch args[0] {
 	default:
-		return fmt.Errorf("invalid command")
+		return rn.unknownSub("site", args[0])
 	case "publish":
 		var opts client.SitePublishOptions
 		f.StringVar(&opts.Project, "project", "", "project id")

--- a/internal/runner/waf.go
+++ b/internal/runner/waf.go
@@ -2,7 +2,6 @@ package runner
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"os"
 
@@ -11,8 +10,8 @@ import (
 )
 
 func (rn Runner) waf(args ...string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("invalid command")
+	if len(args) == 0 || IsHelpArg(args[0]) {
+		return rn.groupUsage("waf")
 	}
 
 	s := rn.API.WAF()
@@ -22,11 +21,10 @@ func (rn Runner) waf(args ...string) error {
 		err  error
 	)
 
-	f := flag.NewFlagSet("", flag.ExitOnError)
-	rn.registerFlags(f)
+	f := rn.subFlagSet("waf", args[0])
 	switch args[0] {
 	default:
-		return fmt.Errorf("invalid command")
+		return rn.unknownSub("waf", args[0])
 	case "get":
 		var req api.WAFGet
 		f.StringVar(&req.Project, "project", "", "project id")

--- a/main.go
+++ b/main.go
@@ -14,9 +14,14 @@ import (
 )
 
 func main() {
-	args := os.Args
-	if len(args) <= 1 {
-		help()
+	args := os.Args[1:]
+	// Fast path for the bare/top-level help invocation: print usage without
+	// building the api client (which may resolve Application Default
+	// Credentials). Group- and subcommand-level help (`deploys me -h`, etc.) is
+	// dispatched through Run below and still pays that lookup, but it returns
+	// before making any API call, so the resolved token is simply unused.
+	if len(args) == 0 || (len(args) == 1 && runner.IsHelpArg(args[0])) {
+		runner.PrintUsage(os.Stdout)
 		return
 	}
 
@@ -54,7 +59,7 @@ func main() {
 		Output: os.Stdout,
 	}
 
-	err := rn.Run(args[1:]...)
+	err := rn.Run(args...)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
@@ -73,46 +78,4 @@ func getDefaultToken() (string, error) {
 	}
 
 	return tk.AccessToken, nil
-}
-
-func help() {
-	fmt.Print(`deploys.app cli
-
-Usage:
-  deploys <command> <subcommand> [flags]
-
-Commands:
-  me                      get, authorized, permissions
-  billing                 create, list, get, update, delete, report, skus, project,
-                          invoices, invoice, downloadinvoice, downloadreceipt
-  location                list, get
-  project                 create, list, get, update, delete, usage
-  role                    create, list, get, delete, grant, revoke, users, bind,
-                          permissions
-  deployment, deploy, d   list, get, deploy, delete, revisions, pause, resume,
-                          restart, rollback, metrics, set
-  domain                  create, get, list, delete, purgecache
-  route                   create, get, list, delete
-  waf                     get, list, set, delete, metrics, limitmetrics
-  cache                   get, list, set, delete, metrics
-  disk                    create, get, list, update, delete, metrics
-  pullsecret, ps          create, get, list, delete
-  workloadidentity, wi    create, get, list, delete
-  serviceaccount, sa      create, get, list, update, delete, createkey, deletekey
-  email                   send, list
-  registry                list, get, tags, manifests, storage, delete,
-                          deletemanifest, untag, metrics
-  envgroup, eg            create, get, list, update, delete
-  auditlog                list
-  dropbox                 list, metrics, upload
-  github                  link, unlink, update, list
-  site                    publish
-
-Flags:
-  -output table|yaml|json (or -oyaml, -ojson, -otable)
-
-Environment:
-  DEPLOYS_TOKEN           api token
-  DEPLOYS_ENDPOINT        override api endpoint
-`)
 }


### PR DESCRIPTION
## Summary

The `deploys` CLI only printed help for a bare `deploys` invocation. Every other help path was broken or bare:

- `deploys <group>` → `invalid command`
- `deploys <group> -h` / `--help` → `invalid command`
- `deploys <group> <sub> -h` → the `flag` package's default banner, with an empty flag-set name (`Usage of :`) and no description of what the command does.

This adds intentional, consistent help at all three levels, driven by a single command registry.

## What you get

- **Top level** — `deploys`, `deploys help`, `deploys -h`, `deploys --help` print the command list. The bare/top-level form short-circuits before building the api client, so it needs no credentials.
- **Group level** — `deploys <group>` (and `-h` / `--help` / `help`, including aliases like `d`, `eg`, `sa`, `ps`, `wi`) lists the group's subcommands with one-line summaries.
- **Subcommand level** — `deploys <group> <sub> -h` / `--help` prints the command's description, a usage line, and its flags (rendered from the live flag set, so it always matches what the command accepts).
- **Unknown subcommands** return a helpful `unknown subcommand "x" (run "deploys <group> -h")` instead of a bare `invalid command`.

The `deployment deploy`, `deployment set` / `set image`, and `site publish` leaves route through the same renderer, so every help path is consistent and writes to `Runner.Output`.

### Example

```
$ deploys deployment metrics -h
show deployment metrics

Usage: deploys deployment metrics [-time-range 1h|6h|12h|1d] [flags]

Flags:
  -location string
    	location
  -name string
    	deployment name
  -output string
    	output mode: table, yaml, json (default "table")
  -project string
    	project id
  -time-range string
    	time range (1h, 6h, 12h, 1d) (default "1h")
```

## Implementation notes

- New `internal/runner/help.go` holds the registry (the single source of truth for all help text, replacing the hand-maintained blob that used to live in `main.go`) plus the top/group/subcommand renderers and a `subFlagSet` helper that names each leaf flag set and wires its `-h` banner.
- Each group method gained a small, uniform preamble; the dispatch switches are otherwise unchanged.
- A registry `INVARIANT` comment documents that it must stay in sync with the dispatch switches.

## Tests

`go build ./... && go vet ./... && go test ./...` all green (18 tests). New coverage:

- The shared `-output` flag still binds to the `Runner` whose `print()` runs (the trickiest part of the refactor).
- Every registry entry is described and resolves by name/alias.
- The renderers (top/group/sub) and the `deployment deploy` banner honor the injected writer.
- Top- and group-level help render without touching the API.

A multi-agent adversarial review was run over the change; its confirmed findings (deploy banner output routing, registry-drift guard, a dead `args` field, and a misleading comment) are all addressed in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)