### PR TITLE
Add scheduler commands to the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,26 @@ separate from the WAF (a role can hold `cache.*` without `waf.*`).
 
 - `list` `-resource-type -actor -outcome success|failure -after -before -limit`.
 
+### scheduler
+
+Cron-driven outbound HTTP requests (project-scoped, location-less).
+
+- `list` `-project`, `get` / `delete` / `pause` / `resume` / `trigger` `-project -name`.
+- `create` `-project -name -schedule <cron> [-timezone <IANA>] [-method GET] -url <url> [-header KEY=VALUE ...] [-body ...] [-auth-type none|basic|bearer -auth-user <u> -auth-secret <s>] [-insecure-tls] [-paused]`.
+- `update` `-project -name [flags]` — omitted flags are preserved; omit `-auth-secret` to keep the stored secret.
+- `trigger` runs the job once now and prints the invocation result.
+- `logs` `-project -name [-limit] [-after] [-before]` — recent invocations (timestamp, success/failed, latency, status).
+- `-schedule` is a 5-field cron expression or an `@descriptor` (`@hourly`, `@every 30m`). `-after`/`-before` accept RFC 3339 or `YYYY-MM-DD`.
+
+Example:
+
+```bash
+deploys scheduler create -project acme -name daily-health-check \
+  -schedule "0 9 * * *" -timezone Asia/Bangkok \
+  -method POST -url https://example.com/health \
+  -header Content-Type=application/json -body '{"check":true}'
+```
+
 ## Development
 
 ```bash

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/deploys-app/deploys
 go 1.26
 
 require (
-	github.com/deploys-app/api v0.0.0-20260617003501-7fb5bf092448
+	github.com/deploys-app/api v0.0.0-20260617143732-b136e2ccf0ea
 	golang.org/x/oauth2 v0.14.0
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:W
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deploys-app/api v0.0.0-20260617003501-7fb5bf092448 h1:OJrGQoFGSSzHrcpqhokHRWDWpsrPyBSW5ic6bpW0j3A=
-github.com/deploys-app/api v0.0.0-20260617003501-7fb5bf092448/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
+github.com/deploys-app/api v0.0.0-20260617143732-b136e2ccf0ea h1:WKsP9EyT42rSpqfO0sIrGhjz8pnktvMuNwyzE6oq488=
+github.com/deploys-app/api v0.0.0-20260617143732-b136e2ccf0ea/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -144,6 +144,8 @@ func (rn Runner) Run(args ...string) error {
 		return rn.collector(args[1:]...)
 	case "site":
 		return rn.site(args[1:]...)
+	case "scheduler":
+		return rn.scheduler(args[1:]...)
 	}
 }
 

--- a/internal/runner/scheduler.go
+++ b/internal/runner/scheduler.go
@@ -1,0 +1,203 @@
+package runner
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"time"
+
+	"github.com/deploys-app/api"
+)
+
+func (rn Runner) scheduler(args ...string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("invalid command")
+	}
+
+	s := rn.API.Scheduler()
+
+	var (
+		resp any
+		err  error
+	)
+
+	f := flag.NewFlagSet("", flag.ExitOnError)
+	rn.registerFlags(f)
+	switch args[0] {
+	default:
+		return fmt.Errorf("invalid command")
+
+	case "list":
+		var req api.SchedulerList
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.Parse(args[1:])
+		resp, err = s.List(context.Background(), &req)
+
+	case "get":
+		var req api.SchedulerGet
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Name, "name", "", "scheduler job name")
+		f.Parse(args[1:])
+		resp, err = s.Get(context.Background(), &req)
+
+	case "create":
+		var (
+			req      api.SchedulerCreate
+			header   multiFlag
+			authType string
+			authUser string
+			authPass string
+		)
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Name, "name", "", "scheduler job name")
+		f.StringVar(&req.Schedule, "schedule", "", "cron schedule (5-field or @descriptor, e.g. \"*/5 * * * *\")")
+		f.StringVar(&req.Timezone, "timezone", "", "IANA timezone for the schedule (default UTC)")
+		f.StringVar(&req.Method, "method", "GET", "HTTP method")
+		f.StringVar(&req.URL, "url", "", "target URL (http/https)")
+		f.Var(&header, "header", "HTTP header KEY=VALUE (repeatable)")
+		f.StringVar(&req.Body, "body", "", "request body")
+		f.StringVar(&authType, "auth-type", "", "auth type: none|basic|bearer")
+		f.StringVar(&authUser, "auth-user", "", "basic auth username")
+		f.StringVar(&authPass, "auth-secret", "", "basic auth password or bearer token")
+		f.BoolVar(&req.InsecureSkipVerify, "insecure-tls", false, "skip TLS verification for HTTPS targets")
+		f.BoolVar(&req.Paused, "paused", false, "create the job paused")
+		f.Parse(args[1:])
+		req.Headers, err = parseKV(header)
+		if err != nil {
+			return err
+		}
+		if authType != "" {
+			req.Auth = api.SchedulerAuth{Type: authType, Username: authUser, Secret: authPass}
+		}
+		resp, err = s.Create(context.Background(), &req)
+
+	case "update":
+		// Merge semantics: seed from the existing job, override only the flags
+		// the user explicitly passed (visitedFlags). The auth secret is never
+		// returned by Get, so an omitted -auth-secret leaves it empty and the
+		// server keeps the stored one.
+		var (
+			req         api.SchedulerUpdate
+			header      multiFlag
+			schedule    string
+			timezone    string
+			method      string
+			url         string
+			body        string
+			authType    string
+			authUser    string
+			authPass    string
+			insecureTLS bool
+		)
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Name, "name", "", "scheduler job name")
+		f.StringVar(&schedule, "schedule", "", "cron schedule (5-field or @descriptor)")
+		f.StringVar(&timezone, "timezone", "", "IANA timezone for the schedule")
+		f.StringVar(&method, "method", "", "HTTP method")
+		f.StringVar(&url, "url", "", "target URL (http/https)")
+		f.Var(&header, "header", "HTTP header KEY=VALUE (repeatable; replaces all headers)")
+		f.StringVar(&body, "body", "", "request body")
+		f.StringVar(&authType, "auth-type", "", "auth type: none|basic|bearer")
+		f.StringVar(&authUser, "auth-user", "", "basic auth username")
+		f.StringVar(&authPass, "auth-secret", "", "basic auth password or bearer token (omit to keep existing)")
+		f.BoolVar(&insecureTLS, "insecure-tls", false, "skip TLS verification for HTTPS targets")
+		f.Parse(args[1:])
+		set := visitedFlags(f)
+
+		cur, err := s.Get(context.Background(), &api.SchedulerGet{Project: req.Project, Name: req.Name})
+		if err != nil {
+			return err
+		}
+		req.Schedule = cur.Schedule
+		req.Timezone = cur.Timezone
+		req.Method = cur.Method
+		req.URL = cur.URL
+		req.Headers = cur.Headers
+		req.Body = cur.Body
+		req.Auth = cur.Auth // Type + Username; Secret stays empty so it is preserved
+		req.InsecureSkipVerify = cur.InsecureSkipVerify
+
+		if set["schedule"] {
+			req.Schedule = schedule
+		}
+		if set["timezone"] {
+			req.Timezone = timezone
+		}
+		if set["method"] {
+			req.Method = method
+		}
+		if set["url"] {
+			req.URL = url
+		}
+		if set["body"] {
+			req.Body = body
+		}
+		if set["insecure-tls"] {
+			req.InsecureSkipVerify = insecureTLS
+		}
+		if len(header) > 0 {
+			req.Headers, err = parseKV(header)
+			if err != nil {
+				return err
+			}
+		}
+		if set["auth-type"] {
+			req.Auth.Type = authType
+		}
+		if set["auth-user"] {
+			req.Auth.Username = authUser
+		}
+		if set["auth-secret"] {
+			req.Auth.Secret = authPass
+		}
+		resp, err = s.Update(context.Background(), &req)
+
+	case "delete":
+		var req api.SchedulerDelete
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Name, "name", "", "scheduler job name")
+		f.Parse(args[1:])
+		resp, err = s.Delete(context.Background(), &req)
+
+	case "pause":
+		var req api.SchedulerPause
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Name, "name", "", "scheduler job name")
+		f.Parse(args[1:])
+		resp, err = s.Pause(context.Background(), &req)
+
+	case "resume":
+		var req api.SchedulerResume
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Name, "name", "", "scheduler job name")
+		f.Parse(args[1:])
+		resp, err = s.Resume(context.Background(), &req)
+
+	case "trigger":
+		var req api.SchedulerTrigger
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Name, "name", "", "scheduler job name")
+		f.Parse(args[1:])
+		resp, err = s.Trigger(context.Background(), &req)
+
+	case "logs":
+		var (
+			req    api.SchedulerLogs
+			after  time.Time
+			before time.Time
+		)
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Name, "name", "", "scheduler job name")
+		f.IntVar(&req.Limit, "limit", 0, "max log entries (default 50, max 100)")
+		f.Var(timeFlag{&after}, "after", "only entries after this time (RFC3339 or YYYY-MM-DD)")
+		f.Var(timeFlag{&before}, "before", "only entries before this time (RFC3339 or YYYY-MM-DD)")
+		f.Parse(args[1:])
+		req.After = after
+		req.Before = before
+		resp, err = s.Logs(context.Background(), &req)
+	}
+	if err != nil {
+		return err
+	}
+	return rn.print(resp)
+}

--- a/main.go
+++ b/main.go
@@ -107,6 +107,7 @@ Commands:
   dropbox                 list, metrics, upload
   github                  link, unlink, update, list
   site                    publish
+  scheduler               create, get, list, update, delete, pause, resume, trigger, logs
 
 Flags:
   -output table|yaml|json (or -oyaml, -ojson, -otable)


### PR DESCRIPTION
Adds `deploys scheduler <create|get|list|update|delete|pause|resume|trigger|logs>` wrapping the new `scheduler.*` API.

- `update` uses `visitedFlags` merge semantics (seed from the existing job, override only the flags passed; omit `-auth-secret` to keep the stored secret), matching the `github` command.
- Headers are `-header KEY=VALUE` (repeatable); auth is `-auth-type` / `-auth-user` / `-auth-secret`; TLS-skip is `-insecure-tls`.
- Adds the help line and a README section.

Depends on **deploys-app/api#81** (merged, pinned in go.mod). This repo has no PR CI — verified locally with `go build` / `go vet` and the usage output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)