### PR TITLE
Tag CLI requests with the cli audit channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ separate from the WAF (a role can hold `cache.*` without `waf.*`).
 
 ### auditlog
 
-- `list` `-resource-type -actor -outcome success|failure -after -before -limit`.
+- `list` `-resource-type -actor -channel api|console|cli|mcp -outcome success|failure -after -before -limit`.
 
 ## Development
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/deploys-app/deploys
 go 1.26
 
 require (
-	github.com/deploys-app/api v0.0.0-20260617003501-7fb5bf092448
+	github.com/deploys-app/api v0.0.0-20260617151946-5463ffa1018a
 	golang.org/x/oauth2 v0.14.0
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:W
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deploys-app/api v0.0.0-20260617003501-7fb5bf092448 h1:OJrGQoFGSSzHrcpqhokHRWDWpsrPyBSW5ic6bpW0j3A=
-github.com/deploys-app/api v0.0.0-20260617003501-7fb5bf092448/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
+github.com/deploys-app/api v0.0.0-20260617151946-5463ffa1018a h1:9MtYCLjU/ofDUQJokguE23t5EHZCkZ4/PLppWGNkqKQ=
+github.com/deploys-app/api v0.0.0-20260617151946-5463ffa1018a/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/internal/runner/auditlog.go
+++ b/internal/runner/auditlog.go
@@ -27,15 +27,25 @@ func (rn Runner) auditLog(args ...string) error {
 		var (
 			req     api.AuditLogList
 			outcome string
+			channel string
 		)
 		f.StringVar(&req.Project, "project", "", "project id")
 		f.StringVar(&req.ResourceType, "resource-type", "", "filter by resource type")
 		f.StringVar(&req.Actor, "actor", "", "filter by actor email")
+		f.StringVar(&channel, "channel", "", "filter by channel (api, console, cli, mcp)")
 		f.StringVar(&outcome, "outcome", "", "filter by outcome (success, failure)")
 		f.Var(timeFlag{&req.After}, "after", "only entries after this time (RFC 3339 or YYYY-MM-DD)")
 		f.Var(timeFlag{&req.Before}, "before", "only entries before this time (RFC 3339 or YYYY-MM-DD)")
 		f.IntVar(&req.Limit, "limit", 0, "max entries")
 		f.Parse(args[1:])
+
+		switch api.AuditChannel(channel) {
+		case "":
+		case api.AuditChannelAPI, api.AuditChannelConsole, api.AuditChannelCLI, api.AuditChannelMCP:
+			req.Channel = api.AuditChannel(channel)
+		default:
+			return fmt.Errorf("invalid channel: '%s'", channel)
+		}
 
 		switch outcome {
 		case "":

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/deploys-app/api"
 	"github.com/deploys-app/api/client"
 	"golang.org/x/oauth2/google"
 
@@ -34,6 +35,7 @@ func main() {
 
 	apiClient := &client.Client{
 		Endpoint: endpoint,
+		Channel:  api.AuditChannelCLI,
 		HTTPClient: &http.Client{
 			Timeout: 15 * time.Second,
 		},


### PR DESCRIPTION
## What

- Sets `client.Channel = api.AuditChannelCLI` on the CLI's api client, so the apiserver records audit log entries from `deploys` under the `cli` channel.
- Adds a `--channel api|console|cli|mcp` filter to `deploys auditlog list` (validated; invalid values error). The channel itself is already surfaced in `auditlog list` output (YAML/JSON) via the api `channel` field.

Depends on deploys-app/api#82 (merged); bumps the api dep to that commit.

## Verification

`go build ./... && go vet ./... && go test ./...` pass locally (this repo has no PR CI).

## Rollout note

⚠️ **Do not merge until the apiserver migration (deploys-app/apiserver#148) is applied in prod.** The `X-Deploys-Channel` header this sends is harmlessly ignored until the `channel` column exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)