### PR TITLE
feat: add check-update command

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,6 +9,9 @@ jobs:
     name: Build
     steps:
     - uses: actions/checkout@v6
+    - name: Short SHA
+      id: vars
+      run: echo "sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
     - uses: google-github-actions/auth@v3
       id: auth
       with:
@@ -36,6 +39,8 @@ jobs:
       with:
         provenance: false
         push: true
+        build-args: |
+          VERSION=nightly-${{ steps.vars.outputs.sha }}
         tags: |
           asia-southeast1-docker.pkg.dev/deploys-app/public/cli:${{ github.sha }}
           registry.deploys.app/public/deploys-cli:${{ github.sha }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -101,6 +101,8 @@ jobs:
       with:
         provenance: false
         push: true
+        build-args: |
+          VERSION=${{ github.ref_name }}
         tags: |
           asia-southeast1-docker.pkg.dev/deploys-app/public/cli:${{ github.ref_name }}
           asia-southeast1-docker.pkg.dev/deploys-app/public/cli:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,14 @@ ENV CGO_ENABLED=0
 
 WORKDIR /workspace
 
+# VERSION stamps the binary so `deploys check-update` can report it; the release
+# workflow passes the git tag. Defaults to "dev" for a plain `docker build`.
+ARG VERSION=dev
+
 ADD go.mod go.sum ./
 RUN go mod download
 ADD . .
-RUN go build -o .build/deploys -ldflags "-w -s" .
+RUN go build -o .build/deploys -ldflags "-w -s -X main.version=${VERSION}" .
 
 FROM debian:13-slim
 

--- a/README.md
+++ b/README.md
@@ -279,8 +279,10 @@ deploys scheduler create -project acme -name daily-health-check \
 Compares this binary's version against the latest stable
 [release](https://github.com/deploys-app/deploys/releases) and reports whether a
 newer one is available. It is a local, credential-free command — it makes no API
-call. Release builds carry their version; a plain `go build` reports `dev` and is
-always treated as out of date.
+call. Release archives and container images carry their release version;
+`go install ...@<version>` and source-checkout builds report the version (or
+commit) the Go toolchain records; the nightly image reports `nightly-<sha>`. A
+build with no version information reports `dev` and is treated as out of date.
 
 ```bash
 deploys check-update          # table (the default)

--- a/README.md
+++ b/README.md
@@ -274,6 +274,17 @@ deploys scheduler create -project acme -name daily-health-check \
   -header Content-Type=application/json -body '{"check":true}'
 ```
 
+### version
+
+Prints this binary's version (see the resolution rules under check-update). The
+default output is the bare version; `-ojson`/`-oyaml` wrap it as a `version`
+object.
+
+```bash
+deploys version          # e.g. v1.1.3
+deploys version -ojson   # { "version": "v1.1.3" }
+```
+
 ### check-update
 
 Compares this binary's version against the latest stable

--- a/README.md
+++ b/README.md
@@ -274,6 +274,19 @@ deploys scheduler create -project acme -name daily-health-check \
   -header Content-Type=application/json -body '{"check":true}'
 ```
 
+### check-update
+
+Compares this binary's version against the latest stable
+[release](https://github.com/deploys-app/deploys/releases) and reports whether a
+newer one is available. It is a local, credential-free command — it makes no API
+call. Release builds carry their version; a plain `go build` reports `dev` and is
+always treated as out of date.
+
+```bash
+deploys check-update          # table (the default)
+deploys check-update -ojson   # { "current": ..., "latest": ..., "updateAvailable": ... }
+```
+
 ## Development
 
 ```bash

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26
 
 require (
 	github.com/deploys-app/api v0.0.0-20260617151946-5463ffa1018a
+	golang.org/x/mod v0.37.0
 	golang.org/x/oauth2 v0.14.0
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUz
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
+golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.18.0 h1:mIYleuAkSbHh0tCv7RvjL3F6ZVbLjq4+R7zbOn3Kokg=
 golang.org/x/net v0.18.0/go.mod h1:/czyP5RqHAH4odGYxBJ1qz0+CE5WZ+2j1YgoEo8F2jQ=

--- a/internal/runner/help.go
+++ b/internal/runner/help.go
@@ -366,8 +366,9 @@ func PrintUsage(w io.Writer) {
 		}
 		fmt.Fprintf(tw, "  %s\t%s\n", name, strings.Join(subs, ", "))
 	}
-	// check-update is a standalone, API-less utility command, not a group with
-	// subcommands, so it lives outside the registry above.
+	// version and check-update are standalone, API-less utility commands, not
+	// groups with subcommands, so they live outside the registry above.
+	fmt.Fprintf(tw, "  %s\t%s\n", "version", "print the cli version")
 	fmt.Fprintf(tw, "  %s\t%s\n", "check-update", "check whether a newer cli version is available")
 	tw.Flush()
 

--- a/internal/runner/help.go
+++ b/internal/runner/help.go
@@ -366,6 +366,9 @@ func PrintUsage(w io.Writer) {
 		}
 		fmt.Fprintf(tw, "  %s\t%s\n", name, strings.Join(subs, ", "))
 	}
+	// check-update is a standalone, API-less utility command, not a group with
+	// subcommands, so it lives outside the registry above.
+	fmt.Fprintf(tw, "  %s\t%s\n", "check-update", "check whether a newer cli version is available")
 	tw.Flush()
 
 	fmt.Fprint(w, "\nFlags:\n")

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -151,6 +151,8 @@ func (rn Runner) Run(args ...string) error {
 		return rn.scheduler(args[1:]...)
 	case "check-update":
 		return rn.checkUpdate(args[1:]...)
+	case "version":
+		return rn.version(args[1:]...)
 	}
 }
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -22,6 +22,9 @@ type Runner struct {
 	API        api.Interface
 	Output     *os.File
 	OutputMode string
+	// Version is this binary's version, shown by check-update. Empty for an
+	// unknown/local build (reported as "dev").
+	Version string
 }
 
 func (rn Runner) output() *os.File {
@@ -146,6 +149,8 @@ func (rn Runner) Run(args ...string) error {
 		return rn.site(args[1:]...)
 	case "scheduler":
 		return rn.scheduler(args[1:]...)
+	case "check-update":
+		return rn.checkUpdate(args[1:]...)
 	}
 }
 

--- a/internal/runner/update.go
+++ b/internal/runner/update.go
@@ -1,0 +1,166 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/mod/semver"
+)
+
+// githubLatestURL returns the latest *stable* release of the cli. The rolling
+// "nightly" prerelease is excluded by the releases/latest endpoint, so this is
+// always a tagged release like "v1.2.3". It is a package var so tests can point
+// it at an httptest server.
+var githubLatestURL = "https://api.github.com/repos/deploys-app/deploys/releases/latest"
+
+// IsLocalCommand reports whether name is a command that runs entirely locally
+// and needs no API client, so main can skip building one (and resolving Google
+// credentials) for it.
+func IsLocalCommand(name string) bool {
+	switch name {
+	case "check-update":
+		return true
+	}
+	return false
+}
+
+// updateCheck is the result of `deploys check-update`.
+type updateCheck struct {
+	Current         string `json:"current" yaml:"current"`
+	Latest          string `json:"latest" yaml:"latest"`
+	UpdateAvailable bool   `json:"updateAvailable" yaml:"updateAvailable"`
+}
+
+func (u updateCheck) Table() [][]string {
+	return [][]string{
+		{"CURRENT", "LATEST", "UPDATE AVAILABLE"},
+		{u.Current, u.Latest, strconv.FormatBool(u.UpdateAvailable)},
+	}
+}
+
+// checkUpdate compares this binary's version against the latest stable release
+// and reports whether a newer one is available.
+func (rn Runner) checkUpdate(args ...string) error {
+	if len(args) > 0 && IsHelpArg(args[0]) {
+		writeCheckUpdateUsage(rn.output())
+		return nil
+	}
+
+	f := flag.NewFlagSet("deploys check-update", flag.ExitOnError)
+	f.SetOutput(rn.output())
+	rn.registerFlags(f)
+	f.Usage = func() { writeCheckUpdateUsage(rn.output()) }
+	if err := f.Parse(args); err != nil {
+		return err
+	}
+
+	latest, err := fetchLatestVersion(context.Background(), githubLatestURL)
+	if err != nil {
+		return fmt.Errorf("check-update: %w", err)
+	}
+
+	res := updateCheck{
+		Current:         displayVersion(rn.Version),
+		Latest:          displayVersion(latest),
+		UpdateAvailable: updateAvailable(rn.Version, latest),
+	}
+	if err := rn.print(res); err != nil {
+		return err
+	}
+
+	// In the default human view, follow up with how to upgrade.
+	if res.UpdateAvailable && (rn.OutputMode == "" || rn.OutputMode == "table") {
+		fmt.Fprintf(rn.output(),
+			"\nA newer release (%s) is available. Upgrade with:\n"+
+				"  go install github.com/deploys-app/deploys@latest\n"+
+				"or download it from https://github.com/deploys-app/deploys/releases\n",
+			res.Latest)
+	}
+	return nil
+}
+
+// fetchLatestVersion reads the latest release tag from the GitHub releases API.
+func fetchLatestVersion(ctx context.Context, url string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	// GitHub rejects API requests without a User-Agent.
+	req.Header.Set("User-Agent", "deploys-cli")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("github api returned %s", resp.Status)
+	}
+
+	var body struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&body); err != nil {
+		return "", err
+	}
+	if body.TagName == "" {
+		return "", errors.New("github api returned an empty tag_name")
+	}
+	return body.TagName, nil
+}
+
+// updateAvailable reports whether latest is newer than current. A build whose
+// version isn't valid semver (a local `go build`, reported as "dev") can't be
+// compared, so any real release is treated as an upgrade.
+func updateAvailable(current, latest string) bool {
+	cv, lv := normalizeVersion(current), normalizeVersion(latest)
+	if !semver.IsValid(lv) {
+		return false
+	}
+	if !semver.IsValid(cv) {
+		return true
+	}
+	return semver.Compare(cv, lv) < 0
+}
+
+// normalizeVersion makes v comparable by golang.org/x/mod/semver, which
+// requires a leading "v" (goreleaser strips it from the binary's version).
+func normalizeVersion(v string) string {
+	v = strings.TrimSpace(v)
+	if v != "" && !strings.HasPrefix(v, "v") {
+		v = "v" + v
+	}
+	return v
+}
+
+// displayVersion renders v for output: canonical "vX.Y.Z" when it is valid
+// semver, otherwise the raw string (e.g. "dev").
+func displayVersion(v string) string {
+	if n := normalizeVersion(v); semver.IsValid(n) {
+		return n
+	}
+	if v == "" {
+		return "dev"
+	}
+	return v
+}
+
+func writeCheckUpdateUsage(w io.Writer) {
+	fmt.Fprint(w, "check-update — check whether a newer deploys cli release is available\n\n")
+	fmt.Fprint(w, "Usage:\n  deploys check-update [-output table|yaml|json]\n\n")
+	fmt.Fprint(w, "Compares this binary's version against the latest stable release on GitHub\n")
+	fmt.Fprint(w, "and prints whether an upgrade is available.\n")
+}

--- a/internal/runner/update.go
+++ b/internal/runner/update.go
@@ -26,10 +26,48 @@ var githubLatestURL = "https://api.github.com/repos/deploys-app/deploys/releases
 // credentials) for it.
 func IsLocalCommand(name string) bool {
 	switch name {
-	case "check-update":
+	case "check-update", "version":
 		return true
 	}
 	return false
+}
+
+// versionInfo is the structured form of `deploys version` (for -ojson/-oyaml).
+type versionInfo struct {
+	Version string `json:"version" yaml:"version"`
+}
+
+func (v versionInfo) Table() [][]string {
+	return [][]string{{v.Version}}
+}
+
+// version prints this binary's version. The default view is the bare version
+// string; -ojson/-oyaml wrap it as a {version: ...} object for scripting.
+func (rn Runner) version(args ...string) error {
+	if len(args) > 0 && IsHelpArg(args[0]) {
+		writeVersionUsage(rn.output())
+		return nil
+	}
+
+	f := flag.NewFlagSet("deploys version", flag.ExitOnError)
+	f.SetOutput(rn.output())
+	rn.registerFlags(f)
+	f.Usage = func() { writeVersionUsage(rn.output()) }
+	if err := f.Parse(args); err != nil {
+		return err
+	}
+
+	v := displayVersion(rn.Version)
+	if rn.OutputMode == "" || rn.OutputMode == "table" {
+		fmt.Fprintln(rn.output(), v)
+		return nil
+	}
+	return rn.print(versionInfo{Version: v})
+}
+
+func writeVersionUsage(w io.Writer) {
+	fmt.Fprint(w, "version — print the deploys cli version\n\n")
+	fmt.Fprint(w, "Usage:\n  deploys version [-output table|yaml|json]\n")
 }
 
 // updateCheck is the result of `deploys check-update`.

--- a/internal/runner/update_test.go
+++ b/internal/runner/update_test.go
@@ -132,12 +132,65 @@ func TestCheckUpdateHelpNeedsNoNetwork(t *testing.T) {
 }
 
 func TestIsLocalCommand(t *testing.T) {
-	if !IsLocalCommand("check-update") {
-		t.Error("check-update should be a local command")
+	for _, c := range []string{"check-update", "version"} {
+		if !IsLocalCommand(c) {
+			t.Errorf("%q should be a local command", c)
+		}
 	}
 	for _, c := range []string{"me", "deployment", "site", ""} {
 		if IsLocalCommand(c) {
 			t.Errorf("%q should not be a local command", c)
 		}
+	}
+}
+
+// version prints the bare, canonicalized version by default and a structured
+// object for -ojson; neither path needs an API client.
+func TestVersion(t *testing.T) {
+	cases := []struct {
+		args    []string
+		version string
+		want    string
+	}{
+		{nil, "1.1.3", "v1.1.3\n"},                         // bare, v-prefixed
+		{[]string{"-output", "json"}, "1.1.3", `"v1.1.3"`}, // structured
+		{nil, "dev-1a2b3c4", "dev-1a2b3c4\n"},              // non-semver stays raw
+		{nil, "", "dev\n"},                                 // unknown build
+	}
+	for _, tc := range cases {
+		tmp, err := os.CreateTemp(t.TempDir(), "ver")
+		if err != nil {
+			t.Fatal(err)
+		}
+		rn := Runner{Output: tmp, Version: tc.version} // API intentionally nil
+		if err := rn.version(tc.args...); err != nil {
+			t.Fatalf("version(%v): %v", tc.args, err)
+		}
+		tmp.Close()
+		b, _ := os.ReadFile(tmp.Name())
+		if !strings.Contains(string(b), tc.want) {
+			t.Errorf("version(%v) version=%q = %q; want it to contain %q", tc.args, tc.version, b, tc.want)
+		}
+	}
+}
+
+func TestVersionHelp(t *testing.T) {
+	tmp, err := os.CreateTemp(t.TempDir(), "ver")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tmp.Close()
+	rn := Runner{Output: tmp, Version: "1.1.3"}
+	if err := rn.version("-h"); err != nil {
+		t.Fatalf("version -h: %v", err)
+	}
+	b, _ := os.ReadFile(tmp.Name())
+	out := string(b)
+	if !strings.Contains(out, "print the deploys cli version") {
+		t.Errorf("version -h missing banner:\n%s", out)
+	}
+	// -h must not print the version itself, only usage.
+	if strings.Contains(out, "v1.1.3") {
+		t.Errorf("version -h should not print the version:\n%s", out)
 	}
 }

--- a/internal/runner/update_test.go
+++ b/internal/runner/update_test.go
@@ -1,0 +1,143 @@
+package runner
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestUpdateAvailable(t *testing.T) {
+	cases := []struct {
+		current, latest string
+		want            bool
+	}{
+		{"1.0.0", "v1.1.3", true},    // older, goreleaser's v-less form
+		{"v1.1.3", "v1.1.3", false},  // same
+		{"v2.0.0", "v1.1.3", false},  // ahead (local/dev tag)
+		{"dev", "v1.1.3", true},      // unknown build -> any release is newer
+		{"", "v1.1.3", true},         // empty build -> treat as needing update
+		{"v1.0.0", "garbage", false}, // bad latest -> never claim an update
+		{"v1.2.0", "v1.10.0", true},  // numeric, not lexical, comparison
+	}
+	for _, tc := range cases {
+		if got := updateAvailable(tc.current, tc.latest); got != tc.want {
+			t.Errorf("updateAvailable(%q, %q) = %v; want %v", tc.current, tc.latest, got, tc.want)
+		}
+	}
+}
+
+func TestDisplayVersion(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"1.1.3", "v1.1.3"},
+		{"v1.1.3", "v1.1.3"},
+		{"dev", "dev"},
+		{"", "dev"},
+	}
+	for _, tc := range cases {
+		if got := displayVersion(tc.in); got != tc.want {
+			t.Errorf("displayVersion(%q) = %q; want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestFetchLatestVersion(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("User-Agent") == "" {
+			t.Error("request missing User-Agent (GitHub rejects it)")
+		}
+		w.Write([]byte(`{"tag_name":"v1.2.3","name":"v1.2.3"}`))
+	}))
+	defer srv.Close()
+
+	got, err := fetchLatestVersion(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("fetchLatestVersion: %v", err)
+	}
+	if got != "v1.2.3" {
+		t.Errorf("tag = %q; want v1.2.3", got)
+	}
+}
+
+func TestFetchLatestVersionErrors(t *testing.T) {
+	// Non-200 is an error.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	if _, err := fetchLatestVersion(context.Background(), srv.URL); err == nil {
+		t.Error("expected error on 404")
+	}
+	srv.Close()
+
+	// Empty tag_name is an error.
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+	if _, err := fetchLatestVersion(context.Background(), srv.URL); err == nil {
+		t.Error("expected error on empty tag_name")
+	}
+}
+
+// checkUpdate end-to-end against a stub release endpoint, including the upgrade
+// hint shown in the default table view.
+func TestCheckUpdateReportsUpgrade(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"tag_name":"v9.9.9"}`))
+	}))
+	defer srv.Close()
+
+	old := githubLatestURL
+	githubLatestURL = srv.URL
+	defer func() { githubLatestURL = old }()
+
+	tmp, err := os.CreateTemp(t.TempDir(), "out")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tmp.Close()
+
+	rn := Runner{Output: tmp, Version: "1.0.0"} // API intentionally nil
+	if err := rn.checkUpdate(); err != nil {
+		t.Fatalf("checkUpdate: %v", err)
+	}
+
+	b, _ := os.ReadFile(tmp.Name())
+	out := string(b)
+	for _, want := range []string{"v1.0.0", "v9.9.9", "go install", "Upgrade"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("checkUpdate output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// -h must render usage without an API client or a network call.
+func TestCheckUpdateHelpNeedsNoNetwork(t *testing.T) {
+	tmp, err := os.CreateTemp(t.TempDir(), "out")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tmp.Close()
+
+	rn := Runner{Output: tmp}
+	if err := rn.checkUpdate("-h"); err != nil {
+		t.Fatalf("checkUpdate -h: %v", err)
+	}
+	b, _ := os.ReadFile(tmp.Name())
+	if !strings.Contains(string(b), "check whether a newer deploys cli release") {
+		t.Errorf("check-update -h missing banner:\n%s", b)
+	}
+}
+
+func TestIsLocalCommand(t *testing.T) {
+	if !IsLocalCommand("check-update") {
+		t.Error("check-update should be a local command")
+	}
+	for _, c := range []string{"me", "deployment", "site", ""} {
+		if IsLocalCommand(c) {
+			t.Errorf("%q should not be a local command", c)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"runtime/debug"
 	"time"
 
 	"github.com/deploys-app/api"
@@ -13,6 +14,11 @@ import (
 
 	"github.com/deploys-app/deploys/internal/runner"
 )
+
+// version is set at release time via -ldflags "-X main.version=...". For other
+// builds it stays empty and resolveVersion falls back to the module's build
+// info.
+var version string
 
 func main() {
 	args := os.Args[1:]
@@ -26,6 +32,25 @@ func main() {
 		return
 	}
 
+	rn := runner.Runner{
+		Output:  os.Stdout,
+		Version: resolveVersion(),
+	}
+
+	// Local utility commands (check-update) run entirely client-side; skip
+	// building the api client so they never resolve Google credentials.
+	if !runner.IsLocalCommand(args[0]) {
+		rn.API = newAPIClient()
+	}
+
+	err := rn.Run(args...)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+func newAPIClient() *client.Client {
 	var (
 		token    = os.Getenv("DEPLOYS_TOKEN")
 		authUser = os.Getenv("DEPLOYS_AUTH_USER")
@@ -56,16 +81,22 @@ func main() {
 		}
 	}
 
-	rn := runner.Runner{
-		API:    apiClient,
-		Output: os.Stdout,
-	}
+	return apiClient
+}
 
-	err := rn.Run(args...)
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+// resolveVersion reports this binary's version: the release value injected via
+// ldflags, else the module version recorded by the Go toolchain for
+// `go install ...@version` builds, else "dev".
+func resolveVersion() string {
+	if version != "" {
+		return version
 	}
+	if info, ok := debug.ReadBuildInfo(); ok {
+		if v := info.Main.Version; v != "" && v != "(devel)" {
+			return v
+		}
+	}
+	return "dev"
 }
 
 func getDefaultToken() (string, error) {

--- a/main.go
+++ b/main.go
@@ -91,12 +91,45 @@ func resolveVersion() string {
 	if version != "" {
 		return version
 	}
-	if info, ok := debug.ReadBuildInfo(); ok {
-		if v := info.Main.Version; v != "" && v != "(devel)" {
-			return v
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "dev"
+	}
+	// `go install <module>@<version>` records the module version (a tag like
+	// v1.1.3, or a v0.0.0-<date>-<sha> pseudo-version for @main / @<commit>).
+	if v := info.Main.Version; v != "" && v != "(devel)" {
+		return v
+	}
+	// Built from a source checkout (go build / go install . in a clone): fall
+	// back to the VCS revision the toolchain embeds, so the build is still
+	// identifiable (e.g. "dev-1a2b3c4" or "dev-1a2b3c4-dirty").
+	return vcsVersion(info)
+}
+
+// vcsVersion derives a "dev-<shortsha>[-dirty]" string from the build's VCS
+// settings, or "dev" when none are present.
+func vcsVersion(info *debug.BuildInfo) string {
+	var revision string
+	var modified bool
+	for _, s := range info.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			revision = s.Value
+		case "vcs.modified":
+			modified = s.Value == "true"
 		}
 	}
-	return "dev"
+	if revision == "" {
+		return "dev"
+	}
+	if len(revision) > 7 {
+		revision = revision[:7]
+	}
+	v := "dev-" + revision
+	if modified {
+		v += "-dirty"
+	}
+	return v
 }
 
 func getDefaultToken() (string, error) {


### PR DESCRIPTION
## What

Adds a local `deploys check-update` command that tells the user whether a newer CLI release is available, by comparing the running binary's version against the latest stable [GitHub release](https://github.com/deploys-app/deploys/releases).

```
$ deploys check-update
CURRENT   LATEST   UPDATE AVAILABLE
v1.0.0    v1.1.3   true

A newer release (v1.1.3) is available. Upgrade with:
  go install github.com/deploys-app/deploys@latest
or download it from https://github.com/deploys-app/deploys/releases
```

Supports `-ojson`/`-oyaml` like every other command.

## How

- **Credential-free** — `check-update` makes no API call. `main` skips building the api client (and resolving Google ADC) for it via `runner.IsLocalCommand`.
- **Latest release** — read from the GitHub `releases/latest` endpoint (latest *stable* tag; the rolling `nightly` prerelease is excluded). The endpoint URL is a package var so tests point it at an `httptest` server.
- **Comparison** — `golang.org/x/mod/semver`. A `dev`/unparseable current build can't be compared, so any real release is treated as an upgrade.

### Version reporting

`resolveVersion()` resolves, in order:

1. `-ldflags -X main.version` — injected at release time. Goreleaser already injects this into the release archives via its default ldflags; the `Dockerfile` takes a `VERSION` build-arg so the **release** workflow passes the git tag and the **nightly** image (build.yaml) passes `nightly-<short-sha>`.
2. `debug.ReadBuildInfo().Main.Version` — covers `go install ...@<version>`: a tag like `v1.1.3` for `@latest`, or a `v0.0.0-<date>-<sha>` pseudo-version for `@main`/`@<commit>`. A source clone with tags likewise gets a pseudo-version carrying the commit sha.
3. VCS revision fallback — `dev-<short-sha>[-dirty]` for source builds that record no module version.
4. `dev` otherwise.

So `go install`, source clones, release archives, and both container images all report an identifiable version; only a build with no info at all shows `dev`.

## Test

`go vet`, `go test` (25 pass incl. new `update_test.go`: comparison, semver edge cases, httptest fetch, end-to-end upgrade hint, `-h` no-network), and `gofmt` all clean. Verified live against GitHub, across table/json/yaml output, and with injected release/nightly versions; confirmed a normal source clone reports its commit pseudo-version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)