### PR TITLE
runner: add notification command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/deploys-app/deploys
 go 1.26
 
 require (
-	github.com/deploys-app/api v0.0.0-20260617151946-5463ffa1018a
+	github.com/deploys-app/api v0.0.0-20260619070526-dd20e9d51519
 	golang.org/x/mod v0.37.0
 	golang.org/x/oauth2 v0.14.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:W
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deploys-app/api v0.0.0-20260617151946-5463ffa1018a h1:9MtYCLjU/ofDUQJokguE23t5EHZCkZ4/PLppWGNkqKQ=
-github.com/deploys-app/api v0.0.0-20260617151946-5463ffa1018a/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
+github.com/deploys-app/api v0.0.0-20260619070526-dd20e9d51519 h1:mJGQkO48OBhOVHA6ywVCdcttXe/umElcRuEFC45EG58=
+github.com/deploys-app/api v0.0.0-20260619070526-dd20e9d51519/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/internal/runner/help.go
+++ b/internal/runner/help.go
@@ -309,6 +309,19 @@ var commands = []command{
 			{name: "logs", args: "-name [-limit -after -before]", short: "show a job's recent invocations"},
 		},
 	},
+	{
+		name:  "notification",
+		short: "deliver project changes to webhook/discord channels",
+		subs: []subcommand{
+			{name: "create", args: "-name -type <webhook|discord> -url <url> [-secret -insecure-tls -resource-type -action -outcome -disabled]", short: "create a notification channel"},
+			{name: "get", args: "-name", short: "show a notification channel"},
+			{name: "list", short: "list notification channels"},
+			{name: "update", args: "-name [flags]", short: "update a notification channel (omitted flags are preserved)"},
+			{name: "delete", args: "-name", short: "delete a notification channel"},
+			{name: "test", args: "-name", short: "deliver a synthetic change now and print the result"},
+			{name: "deliveries", args: "-name [-limit -after -before]", short: "show recent change deliveries"},
+		},
+	},
 }
 
 // lookupCommand finds a group by its canonical name or any alias.

--- a/internal/runner/notification.go
+++ b/internal/runner/notification.go
@@ -1,0 +1,172 @@
+package runner
+
+import (
+	"context"
+	"time"
+
+	"github.com/deploys-app/api"
+)
+
+func (rn Runner) notification(args ...string) error {
+	if len(args) == 0 || IsHelpArg(args[0]) {
+		return rn.groupUsage("notification")
+	}
+
+	s := rn.API.Notification()
+
+	var (
+		resp any
+		err  error
+	)
+
+	f := rn.subFlagSet("notification", args[0])
+	switch args[0] {
+	default:
+		return rn.unknownSub("notification", args[0])
+
+	case "list":
+		var req api.NotificationList
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.Parse(args[1:])
+		resp, err = s.List(context.Background(), &req)
+
+	case "get":
+		var req api.NotificationGet
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Name, "name", "", "channel name")
+		f.Parse(args[1:])
+		resp, err = s.Get(context.Background(), &req)
+
+	case "create":
+		var (
+			req           api.NotificationCreate
+			typ           string
+			url           string
+			secret        string
+			insecureTLS   bool
+			resourceTypes multiFlag
+			actions       multiFlag
+			outcomes      multiFlag
+			disabled      bool
+		)
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Name, "name", "", "channel name")
+		f.StringVar(&typ, "type", "", "channel type: webhook or discord")
+		f.StringVar(&url, "url", "", "delivery URL (http/https)")
+		f.StringVar(&secret, "secret", "", "webhook signing secret (required for webhook)")
+		f.BoolVar(&insecureTLS, "insecure-tls", false, "skip TLS verification for HTTPS targets")
+		f.Var(&resourceTypes, "resource-type", "resource type to subscribe to (repeatable; empty = all)")
+		f.Var(&actions, "action", "action to subscribe to (repeatable; empty = all)")
+		f.Var(&outcomes, "outcome", "outcome to subscribe to: success or failure (repeatable; empty = all)")
+		f.BoolVar(&disabled, "disabled", false, "create the channel disabled")
+		f.Parse(args[1:])
+		req.Config = api.NotificationConfig{Type: typ, URL: url, Secret: secret, InsecureSkipVerify: insecureTLS}
+		req.Subscription = api.NotificationSubscription{
+			ResourceTypes: []string(resourceTypes),
+			Actions:       []string(actions),
+			Outcomes:      []string(outcomes),
+		}
+		req.Disabled = disabled
+		resp, err = s.Create(context.Background(), &req)
+
+	case "update":
+		// Merge semantics: seed from the existing channel, override only the flags
+		// the user explicitly passed (visitedFlags). The signing secret is never
+		// returned by Get, so an omitted -secret leaves it empty and the server
+		// keeps the stored one. A subscription axis is replaced only when at least
+		// one value is passed for it.
+		var (
+			req           api.NotificationUpdate
+			typ           string
+			url           string
+			secret        string
+			insecureTLS   bool
+			resourceTypes multiFlag
+			actions       multiFlag
+			outcomes      multiFlag
+			disabled      bool
+		)
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Name, "name", "", "channel name")
+		f.StringVar(&typ, "type", "", "channel type: webhook or discord")
+		f.StringVar(&url, "url", "", "delivery URL (http/https)")
+		f.StringVar(&secret, "secret", "", "webhook signing secret (omit to keep existing)")
+		f.BoolVar(&insecureTLS, "insecure-tls", false, "skip TLS verification for HTTPS targets")
+		f.Var(&resourceTypes, "resource-type", "resource type to subscribe to (repeatable; replaces all)")
+		f.Var(&actions, "action", "action to subscribe to (repeatable; replaces all)")
+		f.Var(&outcomes, "outcome", "outcome to subscribe to (repeatable; replaces all)")
+		f.BoolVar(&disabled, "disabled", false, "disable the channel")
+		f.Parse(args[1:])
+		set := visitedFlags(f)
+
+		// A distinct name avoids shadowing the outer err so a later Update error
+		// still surfaces after the switch.
+		cur, getErr := s.Get(context.Background(), &api.NotificationGet{Project: req.Project, Name: req.Name})
+		if getErr != nil {
+			return getErr
+		}
+		req.Config = cur.Config // Type + URL + InsecureSkipVerify; Secret stays empty so it is preserved
+		req.Subscription = cur.Subscription
+		req.Disabled = cur.Disabled
+
+		if set["type"] {
+			req.Config.Type = typ
+		}
+		if set["url"] {
+			req.Config.URL = url
+		}
+		if set["secret"] {
+			req.Config.Secret = secret
+		}
+		if set["insecure-tls"] {
+			req.Config.InsecureSkipVerify = insecureTLS
+		}
+		if len(resourceTypes) > 0 {
+			req.Subscription.ResourceTypes = []string(resourceTypes)
+		}
+		if len(actions) > 0 {
+			req.Subscription.Actions = []string(actions)
+		}
+		if len(outcomes) > 0 {
+			req.Subscription.Outcomes = []string(outcomes)
+		}
+		if set["disabled"] {
+			req.Disabled = disabled
+		}
+		resp, err = s.Update(context.Background(), &req)
+
+	case "delete":
+		var req api.NotificationDelete
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Name, "name", "", "channel name")
+		f.Parse(args[1:])
+		resp, err = s.Delete(context.Background(), &req)
+
+	case "test":
+		var req api.NotificationTest
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Name, "name", "", "channel name")
+		f.Parse(args[1:])
+		resp, err = s.Test(context.Background(), &req)
+
+	case "deliveries":
+		var (
+			req    api.NotificationDeliveries
+			after  time.Time
+			before time.Time
+		)
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Name, "name", "", "channel name")
+		f.IntVar(&req.Limit, "limit", 0, "max delivery entries (default 50, max 100)")
+		f.Var(timeFlag{&after}, "after", "only entries after this time (RFC3339 or YYYY-MM-DD)")
+		f.Var(timeFlag{&before}, "before", "only entries before this time (RFC3339 or YYYY-MM-DD)")
+		f.Parse(args[1:])
+		req.After = after
+		req.Before = before
+		resp, err = s.Deliveries(context.Background(), &req)
+	}
+	if err != nil {
+		return err
+	}
+	return rn.print(resp)
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -149,6 +149,8 @@ func (rn Runner) Run(args ...string) error {
 		return rn.site(args[1:]...)
 	case "scheduler":
 		return rn.scheduler(args[1:]...)
+	case "notification":
+		return rn.notification(args[1:]...)
 	case "check-update":
 		return rn.checkUpdate(args[1:]...)
 	case "version":


### PR DESCRIPTION
PR8 of the **notification-channels** feature. Adds the `deploys notification` command, mirroring `deploys scheduler`.

```
deploys notification create -name ops -type webhook -url https://… -secret … \
  -resource-type deployment -action deploy -outcome failure
deploys notification list|get|update|delete|test|deliveries -name ops
```

- Config via `-type`/`-url`/`-secret`/`-insecure-tls`; subscription via repeatable `-resource-type`/`-action`/`-outcome` (empty = all).
- `update` fetches the channel and overrides only the explicitly-passed flags; the write-only `-secret` is kept when omitted (avoids the err-shadowing the scheduler `update` has, so an Update error still surfaces).
- Bumps the `api` module to the merged commit; registered in the root dispatch + help registry.

`go build`/`vet`/`gofmt`/`test` pass; `deploys notification` prints the subcommand help.

🤖 Generated with [Claude Code](https://claude.com/claude-code)