### PR TITLE
runner: fix scheduler update swallowing the update error

### DIFF
--- a/internal/runner/scheduler.go
+++ b/internal/runner/scheduler.go
@@ -101,9 +101,12 @@ func (rn Runner) scheduler(args ...string) error {
 		f.Parse(args[1:])
 		set := visitedFlags(f)
 
-		cur, err := s.Get(context.Background(), &api.SchedulerGet{Project: req.Project, Name: req.Name})
-		if err != nil {
-			return err
+		// A distinct name avoids shadowing the outer err in this case block —
+		// otherwise the s.Update below would assign the shadowed err and the
+		// after-switch error check would silently miss a failed update.
+		cur, getErr := s.Get(context.Background(), &api.SchedulerGet{Project: req.Project, Name: req.Name})
+		if getErr != nil {
+			return getErr
 		}
 		req.Schedule = cur.Schedule
 		req.Timezone = cur.Timezone


### PR DESCRIPTION
Follow-up bug fix found while adding the `notification` command.

## Bug

`deploys scheduler update` fetch-merges the existing job before updating:

```go
var ( resp any; err error )
switch args[0] {
case "update":
    ...
    cur, err := s.Get(...)   // <- a switch case is its own block, so this
    if err != nil { ... }    //    declares a NEW err that SHADOWS the outer one
    ...
    resp, err = s.Update(...) // assigns the *shadowed* err
}
if err != nil { return err }  // checks the *outer* err — still nil
return rn.print(resp)         // on a failed update: prints nil, exits 0
```

So a failed `scheduler update` (validation error, not-found, forbidden, …) was **silently swallowed** — the CLI printed a nil result and exited 0 instead of surfacing the error.

## Fix

Rename the `Get`'s error to `getErr` so it no longer shadows the function-scope `err`; the `Update` error now reaches the after-switch check. One-line-class change.

(The new `notification update` command was written correctly with this same `getErr` pattern, so it never had the bug.)

`go build`/`vet`/`gofmt`/`test` pass. The `internal/runner` package has no test harness (no `api.Interface` fake), so this is verified by build + reasoning rather than a new regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)