### PR TITLE
runner: add registry gc command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/deploys-app/deploys
 go 1.26
 
 require (
-	github.com/deploys-app/api v0.0.0-20260619070526-dd20e9d51519
+	github.com/deploys-app/api v0.0.0-20260620074112-82cdc00752f0
 	golang.org/x/mod v0.37.0
 	golang.org/x/oauth2 v0.14.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:W
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deploys-app/api v0.0.0-20260619070526-dd20e9d51519 h1:mJGQkO48OBhOVHA6ywVCdcttXe/umElcRuEFC45EG58=
-github.com/deploys-app/api v0.0.0-20260619070526-dd20e9d51519/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
+github.com/deploys-app/api v0.0.0-20260620074112-82cdc00752f0 h1:g9WuANHhVnDLL56zaiqrPGaglf5U8SdkQ8QTohJm2QE=
+github.com/deploys-app/api v0.0.0-20260620074112-82cdc00752f0/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/internal/runner/help.go
+++ b/internal/runner/help.go
@@ -246,6 +246,7 @@ var commands = []command{
 			{name: "delete", args: "-repository", short: "delete a repository"},
 			{name: "deletemanifest", args: "-repository -digest", short: "delete a manifest by digest"},
 			{name: "untag", args: "-repository -tag", short: "remove a tag"},
+			{name: "gc", args: "[-dry-run]", short: "garbage-collect manifests no deployment uses"},
 			{name: "metrics", args: "[-time-range 7d|30d|90d]", short: "show registry storage metrics"},
 		},
 	},

--- a/internal/runner/registry.go
+++ b/internal/runner/registry.go
@@ -70,6 +70,12 @@ func (rn Runner) registry(args ...string) error {
 		f.StringVar(&req.Tag, "tag", "", "tag")
 		f.Parse(args[1:])
 		resp, err = s.Untag(context.Background(), &req)
+	case "gc":
+		var req api.RegistryGC
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.BoolVar(&req.DryRun, "dry-run", false, "preview what would be removed without deleting")
+		f.Parse(args[1:])
+		resp, err = s.GC(context.Background(), &req)
 	case "metrics":
 		var (
 			req       api.RegistryMetrics


### PR DESCRIPTION
Adds `deploys registry gc -project <id> [-dry-run]`, calling the new `registry.gc` action to garbage-collect manifests no deployment references (across the current revision and all history). `-dry-run` previews what would be removed without deleting. Pins the api module to the merged `registry.gc` commit.

Part of the registry.gc rollout: api#88 + apiserver#162 (both merged), plus mcp / docs / console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)