### PR TITLE
notification: -event flag replaces -resource-type/-action

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/deploys-app/deploys
 go 1.26
 
 require (
-	github.com/deploys-app/api v0.0.0-20260620074112-82cdc00752f0
+	github.com/deploys-app/api v0.0.0-20260620092348-189c4c56c210
 	golang.org/x/mod v0.37.0
 	golang.org/x/oauth2 v0.14.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/deploys-app/deploys
 go 1.26
 
 require (
-	github.com/deploys-app/api v0.0.0-20260620092348-189c4c56c210
+	github.com/deploys-app/api v0.0.0-20260620094703-501b6b7d5433
 	golang.org/x/mod v0.37.0
 	golang.org/x/oauth2 v0.14.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/deploys-app/api v0.0.0-20260620074112-82cdc00752f0 h1:g9WuANHhVnDLL56zaiqrPGaglf5U8SdkQ8QTohJm2QE=
 github.com/deploys-app/api v0.0.0-20260620074112-82cdc00752f0/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
+github.com/deploys-app/api v0.0.0-20260620092348-189c4c56c210 h1:TPs7iisgB/wDMaTPkG09KutscpG4/4+VqEoO55YmsKI=
+github.com/deploys-app/api v0.0.0-20260620092348-189c4c56c210/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/deploys-app/api v0.0.0-20260620074112-82cdc00752f0 h1:g9WuANHhVnDLL56
 github.com/deploys-app/api v0.0.0-20260620074112-82cdc00752f0/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
 github.com/deploys-app/api v0.0.0-20260620092348-189c4c56c210 h1:TPs7iisgB/wDMaTPkG09KutscpG4/4+VqEoO55YmsKI=
 github.com/deploys-app/api v0.0.0-20260620092348-189c4c56c210/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
+github.com/deploys-app/api v0.0.0-20260620094703-501b6b7d5433 h1:cbsCZwJKN9yTfKmYaBScm5sou0xCgjzN3Rhp6u4cqDk=
+github.com/deploys-app/api v0.0.0-20260620094703-501b6b7d5433/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/internal/runner/help.go
+++ b/internal/runner/help.go
@@ -314,7 +314,7 @@ var commands = []command{
 		name:  "notification",
 		short: "deliver project changes to webhook/discord channels, or pull them",
 		subs: []subcommand{
-			{name: "create", args: "-name -type <webhook|discord|pull> [-url -secret -insecure-tls -pull-ttl -resource-type -action -outcome -disabled]", short: "create a notification channel"},
+			{name: "create", args: "-name -type <webhook|discord|pull> [-url -secret -insecure-tls -pull-ttl -event -outcome -disabled]", short: "create a notification channel"},
 			{name: "get", args: "-name", short: "show a notification channel"},
 			{name: "list", short: "list notification channels"},
 			{name: "update", args: "-name [flags]", short: "update a notification channel (omitted flags are preserved)"},

--- a/internal/runner/notification.go
+++ b/internal/runner/notification.go
@@ -39,16 +39,15 @@ func (rn Runner) notification(args ...string) error {
 
 	case "create":
 		var (
-			req           api.NotificationCreate
-			typ           string
-			url           string
-			secret        string
-			insecureTLS   bool
-			pullTTL       int
-			resourceTypes multiFlag
-			actions       multiFlag
-			outcomes      multiFlag
-			disabled      bool
+			req         api.NotificationCreate
+			typ         string
+			url         string
+			secret      string
+			insecureTLS bool
+			pullTTL     int
+			events      multiFlag
+			outcomes    multiFlag
+			disabled    bool
 		)
 		f.StringVar(&req.Project, "project", "", "project id")
 		f.StringVar(&req.Name, "name", "", "channel name")
@@ -57,16 +56,14 @@ func (rn Runner) notification(args ...string) error {
 		f.StringVar(&secret, "secret", "", "webhook signing secret (required for webhook)")
 		f.BoolVar(&insecureTLS, "insecure-tls", false, "skip TLS verification for HTTPS targets")
 		f.IntVar(&pullTTL, "pull-ttl", 0, "pull channel inactivity TTL in seconds before auto-delete (0 = server default; 60-86400)")
-		f.Var(&resourceTypes, "resource-type", "resource type to subscribe to (repeatable; empty = all)")
-		f.Var(&actions, "action", "action to subscribe to (repeatable; empty = all)")
+		f.Var(&events, "event", "resource.action event to subscribe to: *, deployment.*, *.delete, deployment.deploy (repeatable; empty = all)")
 		f.Var(&outcomes, "outcome", "outcome to subscribe to: success or failure (repeatable; empty = all)")
 		f.BoolVar(&disabled, "disabled", false, "create the channel disabled")
 		f.Parse(args[1:])
 		req.Config = api.NotificationConfig{Type: typ, URL: url, Secret: secret, InsecureSkipVerify: insecureTLS, PullTTLSeconds: pullTTL}
 		req.Subscription = api.NotificationSubscription{
-			ResourceTypes: []string(resourceTypes),
-			Actions:       []string(actions),
-			Outcomes:      []string(outcomes),
+			Events:   []string(events),
+			Outcomes: []string(outcomes),
 		}
 		req.Disabled = disabled
 		resp, err = s.Create(context.Background(), &req)
@@ -78,16 +75,15 @@ func (rn Runner) notification(args ...string) error {
 		// keeps the stored one. A subscription axis is replaced only when at least
 		// one value is passed for it.
 		var (
-			req           api.NotificationUpdate
-			typ           string
-			url           string
-			secret        string
-			insecureTLS   bool
-			pullTTL       int
-			resourceTypes multiFlag
-			actions       multiFlag
-			outcomes      multiFlag
-			disabled      bool
+			req         api.NotificationUpdate
+			typ         string
+			url         string
+			secret      string
+			insecureTLS bool
+			pullTTL     int
+			events      multiFlag
+			outcomes    multiFlag
+			disabled    bool
 		)
 		f.StringVar(&req.Project, "project", "", "project id")
 		f.StringVar(&req.Name, "name", "", "channel name")
@@ -96,8 +92,7 @@ func (rn Runner) notification(args ...string) error {
 		f.StringVar(&secret, "secret", "", "webhook signing secret (omit to keep existing)")
 		f.BoolVar(&insecureTLS, "insecure-tls", false, "skip TLS verification for HTTPS targets")
 		f.IntVar(&pullTTL, "pull-ttl", 0, "pull channel inactivity TTL in seconds (0 = server default; 60-86400)")
-		f.Var(&resourceTypes, "resource-type", "resource type to subscribe to (repeatable; replaces all)")
-		f.Var(&actions, "action", "action to subscribe to (repeatable; replaces all)")
+		f.Var(&events, "event", "resource.action event to subscribe to: *, deployment.*, *.delete (repeatable; replaces all)")
 		f.Var(&outcomes, "outcome", "outcome to subscribe to (repeatable; replaces all)")
 		f.BoolVar(&disabled, "disabled", false, "disable the channel")
 		f.Parse(args[1:])
@@ -128,11 +123,8 @@ func (rn Runner) notification(args ...string) error {
 		if set["pull-ttl"] {
 			req.Config.PullTTLSeconds = pullTTL
 		}
-		if len(resourceTypes) > 0 {
-			req.Subscription.ResourceTypes = []string(resourceTypes)
-		}
-		if len(actions) > 0 {
-			req.Subscription.Actions = []string(actions)
+		if len(events) > 0 {
+			req.Subscription.Events = []string(events)
 		}
 		if len(outcomes) > 0 {
 			req.Subscription.Outcomes = []string(outcomes)


### PR DESCRIPTION
## What

Follows **deploys-app/api#90**: the notification subscription is now a single `events[]` of `resource.action` patterns, so the CLI replaces the separate `-resource-type` and `-action` flags with one repeatable **`-event`** on `notification create`/`update`.

```bash
# only deployment deploys, plus any domain delete
deploys notification create --project acme --name ops --type webhook \
  --url https://hooks.example.com/deploys --secret "$SIGNING_SECRET" \
  --event deployment.deploy --event '*.delete'
```

Patterns: `*`, `deployment.*`, `*.delete`, `deployment.deploy`. `-outcome` is unchanged. Help registry updated; api dep bumped to the #90 commit.

## Verification

`go build`/`go vet`/`go test ./...` (27) pass. No PR CI in this repo, so verified locally per convention. Depends on api#90.