### PR TITLE
notification: stream pull --follow over SSE

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/deploys-app/deploys
 go 1.26
 
 require (
-	github.com/deploys-app/api v0.0.0-20260620104401-36be6a09a7e0
+	github.com/deploys-app/api v0.0.0-20260620111508-f9732bf681a9
 	golang.org/x/mod v0.37.0
 	golang.org/x/oauth2 v0.14.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/deploys-app/deploys
 go 1.26
 
 require (
-	github.com/deploys-app/api v0.0.0-20260620094703-501b6b7d5433
+	github.com/deploys-app/api v0.0.0-20260620104401-36be6a09a7e0
 	golang.org/x/mod v0.37.0
 	golang.org/x/oauth2 v0.14.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/deploys-app/deploys
 go 1.26
 
 require (
-	github.com/deploys-app/api v0.0.0-20260620111508-f9732bf681a9
+	github.com/deploys-app/api v0.0.0-20260620123959-d891c5569d23
 	golang.org/x/mod v0.37.0
 	golang.org/x/oauth2 v0.14.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:W
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deploys-app/api v0.0.0-20260620104401-36be6a09a7e0 h1:511DeCTwFlZUQvi7W3xm9z5l2t6397IMfvXzhURURYA=
-github.com/deploys-app/api v0.0.0-20260620104401-36be6a09a7e0/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
+github.com/deploys-app/api v0.0.0-20260620111508-f9732bf681a9 h1:HEfJ8wY9EBNhawK7RmDEP6FeGKkOy4FfmqyEZYW80/4=
+github.com/deploys-app/api v0.0.0-20260620111508-f9732bf681a9/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:W
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deploys-app/api v0.0.0-20260620111508-f9732bf681a9 h1:HEfJ8wY9EBNhawK7RmDEP6FeGKkOy4FfmqyEZYW80/4=
-github.com/deploys-app/api v0.0.0-20260620111508-f9732bf681a9/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
+github.com/deploys-app/api v0.0.0-20260620123959-d891c5569d23 h1:JDjMpX8nZY3v18OYGR+VmOdZ1KoPcpoxqIygFIJ4mSU=
+github.com/deploys-app/api v0.0.0-20260620123959-d891c5569d23/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/go.sum
+++ b/go.sum
@@ -9,12 +9,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:W
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deploys-app/api v0.0.0-20260620074112-82cdc00752f0 h1:g9WuANHhVnDLL56zaiqrPGaglf5U8SdkQ8QTohJm2QE=
-github.com/deploys-app/api v0.0.0-20260620074112-82cdc00752f0/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
-github.com/deploys-app/api v0.0.0-20260620092348-189c4c56c210 h1:TPs7iisgB/wDMaTPkG09KutscpG4/4+VqEoO55YmsKI=
-github.com/deploys-app/api v0.0.0-20260620092348-189c4c56c210/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
-github.com/deploys-app/api v0.0.0-20260620094703-501b6b7d5433 h1:cbsCZwJKN9yTfKmYaBScm5sou0xCgjzN3Rhp6u4cqDk=
-github.com/deploys-app/api v0.0.0-20260620094703-501b6b7d5433/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
+github.com/deploys-app/api v0.0.0-20260620104401-36be6a09a7e0 h1:511DeCTwFlZUQvi7W3xm9z5l2t6397IMfvXzhURURYA=
+github.com/deploys-app/api v0.0.0-20260620104401-36be6a09a7e0/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/internal/runner/help.go
+++ b/internal/runner/help.go
@@ -321,7 +321,7 @@ var commands = []command{
 			{name: "delete", args: "-name", short: "delete a notification channel"},
 			{name: "test", args: "-name", short: "deliver a synthetic change now and print the result"},
 			{name: "deliveries", args: "-name [-limit -after -before]", short: "show recent change deliveries"},
-			{name: "pull", args: "-name [-ack -limit -follow -interval]", short: "fetch a pull channel's change events (ack to advance; -follow to stream)"},
+			{name: "pull", args: "-name [-ack -limit -follow -poll -interval]", short: "fetch a pull channel's change events (ack to advance; -follow streams over SSE)"},
 		},
 	},
 }

--- a/internal/runner/notification.go
+++ b/internal/runner/notification.go
@@ -2,9 +2,14 @@ package runner
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/deploys-app/api"
+	"github.com/deploys-app/api/client"
+	"gopkg.in/yaml.v2"
 )
 
 func (rn Runner) notification(args ...string) error {
@@ -167,21 +172,24 @@ func (rn Runner) notification(args ...string) error {
 	case "pull":
 		// Consume a pull channel's change events. The server stores the cursor;
 		// pass -ack <cursor> (from a previous pull) to acknowledge that batch and
-		// advance. -follow keeps pulling, auto-acking each batch, until interrupted.
+		// advance. -follow streams new changes as they land (over SSE), printing one
+		// event per line, until interrupted.
 		var (
 			req      api.NotificationPull
 			follow   bool
+			poll     bool
 			interval time.Duration
 		)
 		f.StringVar(&req.Project, "project", "", "project id")
 		f.StringVar(&req.Name, "name", "", "channel name")
 		f.Int64Var(&req.Ack, "ack", 0, "cursor from a previous pull to acknowledge as handled (advances past it)")
 		f.IntVar(&req.Limit, "limit", 0, "max events per batch (default 100, max 1000)")
-		f.BoolVar(&follow, "follow", false, "keep pulling, auto-acking each batch, until interrupted")
-		f.DurationVar(&interval, "interval", 2*time.Second, "poll interval between empty batches when following")
+		f.BoolVar(&follow, "follow", false, "stream new changes as they land (over SSE), until interrupted")
+		f.BoolVar(&poll, "poll", false, "with -follow, use RPC polling instead of the SSE stream")
+		f.DurationVar(&interval, "interval", 2*time.Second, "poll interval between empty batches when following with -poll")
 		f.Parse(args[1:])
 		if follow {
-			return rn.followNotificationPull(s, &req, interval)
+			return rn.followNotificationPull(s, &req, interval, poll)
 		}
 		resp, err = s.Pull(context.Background(), &req)
 	}
@@ -191,19 +199,49 @@ func (rn Runner) notification(args ...string) error {
 	return rn.print(resp)
 }
 
-// followNotificationPull streams a pull channel: pull a batch, print it, then ack
-// it (by passing its cursor as the next request's Ack) so the next pull advances.
-// It blocks until an error or process interrupt; an empty batch waits one interval
-// before retrying. Because each batch is acked only on the next pull, an interrupt
-// mid-batch redelivers it on the next run (at-least-once).
-func (rn Runner) followNotificationPull(s api.Notification, req *api.NotificationPull, interval time.Duration) error {
+// followNotificationPull streams a pull channel's changes until interrupted. By
+// default it uses the server-push SSE transport; it falls back to RPC polling
+// when -poll is set, the concrete client is unavailable, or the server predates
+// the SSE endpoint. Either way delivery is at-least-once — an interrupt before a
+// change is printed redelivers it on the next run — and each change prints on its
+// own line (honoring -output).
+func (rn Runner) followNotificationPull(s api.Notification, req *api.NotificationPull, interval time.Duration, poll bool) error {
+	c, ok := rn.API.(*client.Client)
+	if poll || !ok {
+		return rn.pollNotificationPull(s, req, interval)
+	}
+
+	ctx := context.Background()
+	for {
+		err := c.NotificationPullStream(ctx, req, func(_ int64, ev api.ChangeEventPayload) error {
+			return rn.printNotificationEvent(ev)
+		})
+		switch {
+		case err == nil:
+			// The server closed the stream at its connection cap; reconnect from the
+			// advanced req.Ack.
+			continue
+		case errors.Is(err, client.ErrNotificationStreamUnsupported):
+			// Server without the SSE endpoint — fall back to RPC polling.
+			return rn.pollNotificationPull(s, req, interval)
+		default:
+			return err
+		}
+	}
+}
+
+// pollNotificationPull is the RPC-polling follow loop: pull a batch, print each
+// event, then ack it (by passing the cursor as the next request's Ack). An empty
+// batch waits one interval. Because a batch is acked only on the next pull, an
+// interrupt mid-batch redelivers it (at-least-once).
+func (rn Runner) pollNotificationPull(s api.Notification, req *api.NotificationPull, interval time.Duration) error {
 	for {
 		res, err := s.Pull(context.Background(), req)
 		if err != nil {
 			return err
 		}
-		if len(res.Events) > 0 {
-			if err := rn.print(res); err != nil {
+		for _, ev := range res.Events {
+			if err := rn.printNotificationEvent(ev); err != nil {
 				return err
 			}
 		}
@@ -211,5 +249,30 @@ func (rn Runner) followNotificationPull(s api.Notification, req *api.Notificatio
 		if !res.HasMore {
 			time.Sleep(interval)
 		}
+	}
+}
+
+// printNotificationEvent renders one streamed change, honoring -output: a compact
+// JSON line (NDJSON, ideal for an agent) for json, a YAML document for yaml, and a
+// single tab-separated line (time, actor, action, resource, outcome) otherwise.
+func (rn Runner) printNotificationEvent(ev api.ChangeEventPayload) error {
+	switch rn.OutputMode {
+	case "json":
+		b, err := json.Marshal(ev)
+		if err != nil {
+			return err
+		}
+		_, err = fmt.Fprintln(rn.output(), string(b))
+		return err
+	case "yaml":
+		return yaml.NewEncoder(rn.output()).Encode(ev)
+	default:
+		res := ev.ResourceType
+		if ev.ResourceName != "" {
+			res += "/" + ev.ResourceName
+		}
+		_, err := fmt.Fprintf(rn.output(), "%s\t%s\t%s\t%s\t%s\n",
+			ev.Time.Format(time.RFC3339), ev.Actor, ev.Action, res, ev.Outcome)
+		return err
 	}
 }


### PR DESCRIPTION
## Summary

`deploys notification pull --follow` now streams over the new pull **SSE** transport (apiserver#167, via the api `NotificationPullStream` helper #93): the server pushes change events as they land instead of the CLI polling on an interval.

- **Live push + auto-reconnect**: opens the SSE stream and prints each change as it arrives; when the server closes a stream at its connection cap it reconnects, resuming from the advanced cursor.
- **Per-event output (honors `-output`)**: compact JSON line / NDJSON with `-ojson` (ideal for an AI agent to parse incrementally), a YAML document with `-oyaml`, and a tab-separated `time · actor · action · resource · outcome` line by default.
- **Fallback to RPC polling** when `-poll` is passed (escape hatch for environments that break SSE), the concrete client isn't available, or the server predates the SSE endpoint (detected via `client.ErrNotificationStreamUnsupported`).
- **At-least-once preserved** on both paths: an interrupt before a change is printed redelivers it on the next run.

The one-shot `deploys notification pull` (no `--follow`) is unchanged.

```
deploys notification pull -name agent -project my-proj --follow            # live, human-readable
deploys notification pull -name agent -project my-proj --follow -ojson     # NDJSON for an agent
deploys notification pull -name agent -project my-proj --follow -poll      # force RPC polling
```

## Verification

`go build ./...`, `go vet ./internal/runner/`, `go test ./internal/runner/` (27 pass), `gofmt` clean. (This repo has no PR CI — verified locally.)

## Rollout

PR 3 of 4. Bumps the api dep to the `NotificationPullStream` commit (api#93). Last: docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)