### PR TITLE
chore: bump api for clearer name-validation error messages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/deploys-app/deploys
 go 1.26
 
 require (
-	github.com/deploys-app/api v0.0.0-20260620123959-d891c5569d23
+	github.com/deploys-app/api v0.0.0-20260620135917-09b9bb013a52
 	golang.org/x/mod v0.37.0
 	golang.org/x/oauth2 v0.14.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:W
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deploys-app/api v0.0.0-20260620123959-d891c5569d23 h1:JDjMpX8nZY3v18OYGR+VmOdZ1KoPcpoxqIygFIJ4mSU=
-github.com/deploys-app/api v0.0.0-20260620123959-d891c5569d23/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
+github.com/deploys-app/api v0.0.0-20260620135917-09b9bb013a52 h1:QGkWo52VJ9ogZ/Y7aSMTbJn6k8HlTBvD6jagcumahu0=
+github.com/deploys-app/api v0.0.0-20260620135917-09b9bb013a52/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=


### PR DESCRIPTION
Bumps `github.com/deploys-app/api` to `09b9bb0` to pick up [api#96](https://github.com/deploys-app/api/pull/96).

The CLI validates request names client-side via `Valid()` before sending, so this bump makes the CLI reject a bad name with the plain-English message instead of the raw regexp:

```
name invalid: use lowercase letters, numbers, and hyphens, starting with a letter and ending with a letter or number
```

Message text only — the name constraint is unchanged.

Verified: `go build`/`go vet` clean, `go test ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)