### PR TITLE
deployment: add logs and status subcommands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/deploys-app/deploys
 go 1.26
 
 require (
-	github.com/deploys-app/api v0.0.0-20260620123959-d891c5569d23
+	github.com/deploys-app/api v0.0.0-20260620140617-db3e6e9b55cf
 	golang.org/x/mod v0.37.0
 	golang.org/x/oauth2 v0.14.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:W
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deploys-app/api v0.0.0-20260620123959-d891c5569d23 h1:JDjMpX8nZY3v18OYGR+VmOdZ1KoPcpoxqIygFIJ4mSU=
-github.com/deploys-app/api v0.0.0-20260620123959-d891c5569d23/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
+github.com/deploys-app/api v0.0.0-20260620140617-db3e6e9b55cf h1:dOulfm6ZjOkAOl0ELinWnpi1h9dA92FbJvJ6mT8I2Zw=
+github.com/deploys-app/api v0.0.0-20260620140617-db3e6e9b55cf/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/internal/runner/help.go
+++ b/internal/runner/help.go
@@ -128,6 +128,8 @@ var commands = []command{
 			{name: "restart", short: "restart a deployment"},
 			{name: "rollback", args: "-revision n", short: "roll back to a previous revision"},
 			{name: "metrics", args: "[-time-range 1h|6h|12h|1d]", short: "show deployment metrics"},
+			{name: "status", short: "show pod health and failure reasons"},
+			{name: "logs", args: "[-pod p] [-previous] [-tail n] [-follow]", short: "read a bounded snapshot of recent container logs"},
 			// "set" is the user-facing listing; "set image" is the hidden leaf that
 			// backs its banner. They share wording so the listing and banner agree.
 			{name: "set", short: "roll out a new image (set image <name> -image <ref>)"},

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 	"unicode/utf8"
 
 	"github.com/deploys-app/api"
@@ -489,11 +490,66 @@ func (rn Runner) deployment(args ...string) error {
 		f.Parse(args[1:])
 		req.TimeRange = api.DeploymentMetricsTimeRange(timeRange)
 		resp, err = s.Metrics(context.Background(), &req)
+	case "status":
+		var req api.DeploymentStatus
+		f.StringVar(&req.Location, "location", "", "location")
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Name, "name", "", "deployment name")
+		f.Parse(args[1:])
+		resp, err = s.Status(context.Background(), &req)
+	case "logs":
+		var (
+			req    api.DeploymentLogs
+			follow bool
+		)
+		f.StringVar(&req.Location, "location", "", "location")
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Name, "name", "", "deployment name")
+		f.StringVar(&req.Pod, "pod", "", "single pod name (default: all pods of the deployment)")
+		f.BoolVar(&req.Previous, "previous", false, "read the last crashed container (crash post-mortem)")
+		f.IntVar(&req.TailLines, "tail", 0, "lines per pod (default 200, max 1000)")
+		f.BoolVar(&follow, "follow", false, "re-poll for new lines (client-side; the API stays snapshot-only)")
+		f.Parse(args[1:])
+		if follow {
+			// --follow is a CLI-only convenience: re-poll the bounded snapshot on
+			// an interval and print lines not seen before. The API/MCP contract
+			// stays snapshot-only.
+			return rn.deploymentLogsFollow(s, &req)
+		}
+		resp, err = s.Logs(context.Background(), &req)
 	}
 	if err != nil {
 		return err
 	}
 	return rn.print(resp)
+}
+
+// deploymentLogsFollow client-side tails a deployment by re-polling the bounded
+// deployment.logs snapshot and printing only lines it hasn't printed yet. It
+// runs until interrupted. The seen-set is soft-capped so a long session can't
+// grow it without bound (a reset may reprint the current tail once).
+func (rn Runner) deploymentLogsFollow(s api.Deployment, req *api.DeploymentLogs) error {
+	const seenCap = 20000
+	seen := map[string]bool{}
+	out := rn.output()
+	for {
+		res, err := s.Logs(context.Background(), req)
+		if err != nil {
+			return err
+		}
+		if len(seen) > seenCap {
+			seen = map[string]bool{}
+		}
+		for _, l := range res.Lines {
+			key := l.Timestamp.Format(time.RFC3339Nano) + "\x00" + l.Pod + "\x00" + l.Log
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			fmt.Fprintf(out, "%s %s %s\n", l.Timestamp.Format(time.RFC3339), l.Pod, l.Log)
+		}
+		time.Sleep(2 * time.Second)
+	}
 }
 
 func (rn Runner) route(args ...string) error {


### PR DESCRIPTION
CLI surface for agent observability (`SPEC-agent-observability.md` §G).

## What
- `deploys deployment status --project --location --name` — prints the pod-health table (counts + non-ready pod failure reasons), or yaml/json via `-o`.
- `deploys deployment logs --project --location --name [--pod P] [--previous] [--tail N] [--follow]` — prints the bounded snapshot as table/yaml/json. `--previous` reads the last crashed container.
- `--follow` is a **CLI-only** convenience: it re-polls the bounded snapshot client-side and prints lines it hasn't printed yet. The API/MCP contract stays snapshot-only (one call, one bounded result).

## Dependencies
Bumps `github.com/deploys-app/api` to the contract commit (deploys-app/api#97). No PR CI in this repo — verified locally: `go build ./...` + `go vet ./...` clean; `deployment logs -h` / `deployment status` flag surface checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)