### PR TITLE
dropbox: label the -project flag as the project sid

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/deploys-app/deploys
 go 1.26
 
 require (
-	github.com/deploys-app/api v0.0.0-20260620144341-f44361cacfa9
+	github.com/deploys-app/api v0.0.0-20260621014800-d28662cccb96
 	golang.org/x/mod v0.37.0
 	golang.org/x/oauth2 v0.14.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:W
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deploys-app/api v0.0.0-20260620144341-f44361cacfa9 h1:ALwclb0blOWFuyl/eJ5N5TzxqXE1CcUzIuSYuhf+360=
-github.com/deploys-app/api v0.0.0-20260620144341-f44361cacfa9/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
+github.com/deploys-app/api v0.0.0-20260621014800-d28662cccb96 h1:sLhoZhpJC9b7NWWBX8bnfSm6EOijablesYxaJ9kyO4c=
+github.com/deploys-app/api v0.0.0-20260621014800-d28662cccb96/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/internal/runner/dropbox.go
+++ b/internal/runner/dropbox.go
@@ -29,7 +29,7 @@ func (rn Runner) dropbox(args ...string) error {
 		return rn.unknownSub("dropbox", args[0])
 	case "list":
 		var req api.DropboxList
-		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Project, "project", "", "project sid")
 		f.Var(timeFlag{&req.After}, "after", "only files after this time (RFC 3339 or YYYY-MM-DD)")
 		f.Var(timeFlag{&req.Before}, "before", "only files before this time (RFC 3339 or YYYY-MM-DD)")
 		f.IntVar(&req.Limit, "limit", 0, "max entries")
@@ -40,7 +40,7 @@ func (rn Runner) dropbox(args ...string) error {
 			req       api.DropboxMetrics
 			timeRange string
 		)
-		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Project, "project", "", "project sid")
 		f.StringVar(&timeRange, "time-range", "30d", "time range (7d, 30d, 90d)")
 		f.Parse(args[1:])
 		req.TimeRange = api.UsageMetricsTimeRange(timeRange)
@@ -48,7 +48,7 @@ func (rn Runner) dropbox(args ...string) error {
 	case "upload":
 		var opts client.DropboxUploadOptions
 		var file string
-		f.StringVar(&opts.Project, "project", "", "project id")
+		f.StringVar(&opts.Project, "project", "", "project sid")
 		f.StringVar(&file, "file", "", "path to the file to upload, or - for stdin (default stdin)")
 		f.StringVar(&opts.Filename, "filename", "", "filename recorded in the download (defaults to the base name of -file)")
 		f.IntVar(&opts.TTLDays, "ttl", 0, "download lifetime in days, 1-7 (default 1)")


### PR DESCRIPTION
## What

Makes `deploys dropbox upload --project <sid>` (and `list`/`metrics`) work with a project **sid** end-to-end.

## Change

1. Relabel the `-project` flag help from "project id" → "project sid" on all three subcommands (they all resolve by sid).
2. **Bump `github.com/deploys-app/api`** to the commit that merged deploys-app/api#99, so the upload actually sends `?project=` instead of the numeric-only `?projectId=` and authorizes by sid.

## Verification

`go build ./...` + `go test ./...` pass. Confirmed the resolved api module's `client/dropbox_upload.go` sends `q.Set("project", …)`.

Part of a coordinated change; api#99 is merged. dropbox#21 / mcp#25 / docs#38 are the doc/instruction counterparts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)