### PR TITLE
deployment: add logsHistory CLI subcommand for durable log history

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,14 @@ match the corresponding resource.
 Lifecycle: `list`, `get` `-revision`, `delete`, `revisions`, `pause`, `resume`,
 `rollback` `-revision`, `metrics` `-time-range 1h|6h|12h|1d`, `set image <name> -image ...`.
 
+Logs: `logs` `[-pod] [-tail] [-previous] [-follow]` — live, ephemeral container
+logs (current pods, snapshot). `logsHistory` (alias `logs-history`)
+`-since <RFC3339|24h> [-until] [-pod] [-limit] [-reverse] [-cursor]` — durable
+30-day stored history; `-since` is required and accepts an RFC3339 timestamp or a
+relative duration (`24h`, `1h`, `30m` = now minus that), `-until` defaults to now,
+`-reverse` returns newest-first, and `-cursor` pages through using a prior
+response's `nextCursor`.
+
 `deploy` — create or update a deployment (a merge; omitted flags are preserved).
 
 | Flag | Notes |

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/deploys-app/deploys
 go 1.26
 
 require (
-	github.com/deploys-app/api v0.0.0-20260621014800-d28662cccb96
+	github.com/deploys-app/api v0.0.0-20260621044610-657ba4696617
 	golang.org/x/mod v0.37.0
 	golang.org/x/oauth2 v0.14.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:W
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deploys-app/api v0.0.0-20260621014800-d28662cccb96 h1:sLhoZhpJC9b7NWWBX8bnfSm6EOijablesYxaJ9kyO4c=
-github.com/deploys-app/api v0.0.0-20260621014800-d28662cccb96/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
+github.com/deploys-app/api v0.0.0-20260621044610-657ba4696617 h1:lmoK3YBUv2BLaHc+y6sMX/Uz4jEXO58U/uOPPbT5p6c=
+github.com/deploys-app/api v0.0.0-20260621044610-657ba4696617/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -517,11 +517,52 @@ func (rn Runner) deployment(args ...string) error {
 			return rn.deploymentLogsFollow(s, &req)
 		}
 		resp, err = s.Logs(context.Background(), &req)
+	case "logsHistory", "logs-history":
+		var (
+			req          api.DeploymentLogsHistory
+			since, until string
+		)
+		f.StringVar(&req.Location, "location", "", "location")
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Name, "name", "", "deployment name")
+		f.StringVar(&req.Pod, "pod", "", "single pod name (default: all pods of the deployment)")
+		f.StringVar(&since, "since", "", "window start, RFC3339 or relative (e.g. 24h, 1h, 30m = now minus that); required")
+		f.StringVar(&until, "until", "", "window end, RFC3339 or relative (e.g. 1h); empty defaults to now")
+		f.IntVar(&req.Limit, "limit", 0, "max lines per page (default 200, max 1000)")
+		f.BoolVar(&req.Reverse, "reverse", false, "return newest-first and page backward into the past")
+		f.StringVar(&req.Cursor, "cursor", "", "opaque page cursor from a previous response's nextCursor")
+		f.Parse(args[1:])
+		if req.Since, err = parseHistoryTime(since); err != nil {
+			return fmt.Errorf("invalid -since: %w", err)
+		}
+		if req.Until, err = parseHistoryTime(until); err != nil {
+			return fmt.Errorf("invalid -until: %w", err)
+		}
+		resp, err = s.LogsHistory(context.Background(), &req)
 	}
 	if err != nil {
 		return err
 	}
 	return rn.print(resp)
+}
+
+// parseHistoryTime parses a -since/-until flag value for deployment logs
+// history. An empty value yields the zero time (the server resolves a zero
+// Until to now; a zero Since is rejected upstream as required). A value is
+// either an RFC3339 timestamp or a Go duration (e.g. 24h, 30m) interpreted as
+// now minus that duration.
+func parseHistoryTime(s string) (time.Time, error) {
+	if s == "" {
+		return time.Time{}, nil
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t, nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("expected RFC3339 timestamp or duration (e.g. 24h): %q", s)
+	}
+	return time.Now().Add(-d), nil
 }
 
 // deploymentLogsFollow client-side tails a deployment by re-polling the bounded


### PR DESCRIPTION
## Summary

Adds a `deployment logsHistory` subcommand (alias `logs-history`) to the CLI that reads the new **durable 30-day deployment log history** via the merged `deployment.logsHistory` API action (api#100/#101/#102). It is the retrieval sibling of the live `deployment logs` snapshot: unlike live logs (ephemeral, current pods), history is read from object storage and survives pod restart/redeploy/GC for the retention window. It reuses the secret-bearing `deployment.logs` permission and is available only for locations with a log bucket configured.

## What changed

- `internal/runner/runner.go`
  - New `case "logsHistory", "logs-history"` in `deployment(args...)`, modeled on the `metrics` case (declares extra local string vars, parses, converts, then calls the service).
  - Flags: `-project`, `-location`, `-name` (like the siblings) plus `-pod`, `-since`, `-until`, `-limit` (int), `-reverse` (bool), `-cursor`.
  - `-since`/`-until` accept either an RFC3339 timestamp or a relative duration (`24h`, `1h`, `30m` = now minus that), parsed by a small `parseHistoryTime` helper. Empty `-until` leaves the zero value, which the server resolves to now; empty `-since` is left zero and rejected upstream as required.
  - Builds `api.DeploymentLogsHistory`, calls `s.LogsHistory(...)`, and assigns to `resp`. The result type already implements `Table()`, so it renders through the shared printer.
- `go.mod` / `go.sum`: bumped the `github.com/deploys-app/api` dependency to pick up `DeploymentLogsHistory`.
- `README.md`: documented `logs` and the new `logsHistory` subcommand in the deployment section.

## Verification

- `go build ./...` passes; `go vet ./internal/runner/` clean.
- Smoke-tested the built binary:
  - invalid `-since` → `invalid -since: expected RFC3339 timestamp or duration ...`
  - `logs-history` alias + `-since 24h` → parses and reaches the API (fails only at auth/project lookup, as expected without credentials)
  - unknown flag → rejected with the subcommand usage banner

(No PR CI in this repo; a clean local `go build ./...` is the gate.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)