### PR TITLE
Add deployment errors CLI sub-group (list/get/update)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,14 @@ relative duration (`24h`, `1h`, `30m` = now minus that), `-until` defaults to no
 `-reverse` returns newest-first, and `-cursor` pages through using a prior
 response's `nextCursor`.
 
+Errors: `errors` `[-status open|resolved|muted|all] [-sort lastSeen|firstSeen|count]
+[-limit] [-cursor]` — list detected application error issues (grouped, deduplicated
+stack traces mined from the durable log stream); `-status` defaults to `open`.
+`errors get -id <id>` shows one issue with its representative stack trace and recent
+occurrences; `errors update -id <id> -status resolved|open|muted` changes an issue's
+triage status (resolve, reopen, or mute). History-backed and best-effort, like
+`logsHistory`; available only where log capture is enabled for the location.
+
 `deploy` — create or update a deployment (a merge; omitted flags are preserved).
 
 | Flag | Notes |

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/deploys-app/deploys
 go 1.26
 
 require (
-	github.com/deploys-app/api v0.0.0-20260621044610-657ba4696617
+	github.com/deploys-app/api v0.0.0-20260621114444-0ba48f38fbb7
 	golang.org/x/mod v0.37.0
 	golang.org/x/oauth2 v0.14.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:W
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deploys-app/api v0.0.0-20260621044610-657ba4696617 h1:lmoK3YBUv2BLaHc+y6sMX/Uz4jEXO58U/uOPPbT5p6c=
-github.com/deploys-app/api v0.0.0-20260621044610-657ba4696617/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
+github.com/deploys-app/api v0.0.0-20260621114444-0ba48f38fbb7 h1:bRMPkkBkomba2/SPI1MzEizrTd+FQpImAnfnb9vcXNc=
+github.com/deploys-app/api v0.0.0-20260621114444-0ba48f38fbb7/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/internal/runner/flags.go
+++ b/internal/runner/flags.go
@@ -69,6 +69,14 @@ func (f timeFlag) Set(v string) error {
 	return fmt.Errorf("invalid time '%s' (want RFC 3339 or YYYY-MM-DD)", v)
 }
 
+// isFlag reports whether an argument looks like a flag (starts with "-") rather
+// than a subcommand keyword. A lone "-" is not treated as a flag. It lets a
+// group dispatch a bare, flagless invocation to a default leaf while still
+// routing explicit subcommand keywords.
+func isFlag(arg string) bool {
+	return len(arg) > 1 && arg[0] == '-'
+}
+
 // splitComma splits a comma separated value, dropping empty elements.
 // Returns nil on empty input.
 func splitComma(s string) []string {

--- a/internal/runner/flags_test.go
+++ b/internal/runner/flags_test.go
@@ -53,6 +53,20 @@ func TestTimeFlag(t *testing.T) {
 	}
 }
 
+func TestIsFlag(t *testing.T) {
+	for _, s := range []string{"-id", "--status", "-h", "-x"} {
+		if !isFlag(s) {
+			t.Errorf("isFlag(%q) = false; want true", s)
+		}
+	}
+	// subcommand keywords and a lone "-" are not flags
+	for _, s := range []string{"", "-", "get", "update", "list"} {
+		if isFlag(s) {
+			t.Errorf("isFlag(%q) = true; want false", s)
+		}
+	}
+}
+
 func TestSplitComma(t *testing.T) {
 	if got := splitComma(""); got != nil {
 		t.Errorf("splitComma(\"\") = %v; want nil", got)

--- a/internal/runner/help.go
+++ b/internal/runner/help.go
@@ -134,6 +134,12 @@ var commands = []command{
 			// backs its banner. They share wording so the listing and banner agree.
 			{name: "set", short: "roll out a new image (set image <name> -image <ref>)"},
 			{name: "set image", args: "<name> -image <ref>", short: "roll out a new image for a deployment", hidden: true},
+			// "errors" is the user-facing listing for the error-issue sub-group; the
+			// bare invocation lists issues, while "errors get"/"errors update" are
+			// hidden leaves that back their own banners (mirroring "set"/"set image").
+			{name: "errors", args: "[-status open|resolved|muted|all] [-sort lastSeen|firstSeen|count] [-limit n] [-cursor c]", short: "list detected application error issues (get/update an issue by id)"},
+			{name: "errors get", args: "-id <id>", short: "show an error issue with its sample stack and recent occurrences", hidden: true},
+			{name: "errors update", args: "-id <id> -status resolved|open|muted", short: "change an error issue's triage status (resolve, reopen, or mute)", hidden: true},
 		},
 	},
 	{

--- a/internal/runner/help_test.go
+++ b/internal/runner/help_test.go
@@ -121,6 +121,10 @@ func TestRunHelpNeedsNoAPI(t *testing.T) {
 		{[]string{"me"}, "Subcommands:"},
 		{[]string{"me", "help"}, "identity and access"},
 		{[]string{"d", "-h"}, "deployments and their lifecycle"},
+		// the deployment errors sub-group renders its own banners without an API
+		{[]string{"deployment", "errors", "-h"}, "list detected application error issues"},
+		{[]string{"deployment", "errors", "get", "-h"}, "Usage: deploys deployment errors get"},
+		{[]string{"deployment", "errors", "update", "-h"}, "change an error issue's triage status"},
 	}
 	for _, tc := range cases {
 		if err := tmp.Truncate(0); err != nil {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"time"
 	"unicode/utf8"
 
@@ -401,13 +402,15 @@ func (rn Runner) deployment(args ...string) error {
 		return rn.groupUsage("deployment")
 	}
 
-	// deploy and set own their flag handling (including -h); the shared
+	// deploy, set, and errors own their flag handling (including -h); the shared
 	// subFlagSet below is only for the simple lifecycle subcommands.
 	switch args[0] {
 	case "deploy":
 		return rn.deploymentDeploy(args[1:]...)
 	case "set":
 		return rn.deploymentSet(args[1:]...)
+	case "errors":
+		return rn.deploymentErrors(args[1:]...)
 	}
 
 	s := rn.API.Deployment()
@@ -896,6 +899,130 @@ func (rn Runner) deploymentSet(args ...string) error {
 		}
 		return rn.print(resp)
 	}
+}
+
+// deploymentErrors handles the `deployment errors` sub-group: list (the bare
+// `errors` invocation), get, and update. The bare form lists open issues —
+// mirroring how `deployment errors` reads in the SPEC (list/get/resolve) — so a
+// flagless `deployment errors` does something useful rather than printing usage.
+func (rn Runner) deploymentErrors(args ...string) error {
+	// The bare `errors` form (and any leading flag) is the list; only get and
+	// update are addressed by an explicit subcommand keyword. Resolve the leaf and
+	// its help intent before touching the API, so `errors -h` (and each leaf's -h)
+	// renders without resolving credentials or panicking on a nil API.
+	//
+	// `errors -h`/`errors help`/`errors --help` shows the list banner (the group's
+	// primary action, which lists its own flags). Checked before the isFlag routing
+	// below because -h/--help look like flags but mean "help here", not "list with
+	// this flag".
+	if len(args) > 0 && IsHelpArg(args[0]) {
+		f := rn.subFlagSet("deployment", "errors")
+		f.Usage()
+		return nil
+	}
+
+	leaf := "list"
+	rest := args
+	if len(args) > 0 && !isFlag(args[0]) {
+		leaf = args[0]
+		rest = args[1:]
+	}
+
+	switch leaf {
+	default:
+		return rn.unknownSub("deployment errors", leaf)
+	case "list":
+		var (
+			req    api.DeploymentErrors
+			status string
+			sort   string
+		)
+		f := rn.subFlagSet("deployment", "errors")
+		f.StringVar(&req.Location, "location", "", "location")
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Name, "name", "", "deployment name")
+		f.StringVar(&status, "status", "", "triage status filter: open (default), resolved, muted, all")
+		f.StringVar(&sort, "sort", "", "sort order: lastSeen (default), firstSeen, count")
+		f.IntVar(&req.Limit, "limit", 0, "max issues per page (default 50, max 200)")
+		f.StringVar(&req.Cursor, "cursor", "", "opaque page cursor from a previous response's nextCursor")
+		f.Parse(rest)
+		req.Status = status
+		req.Sort = sort
+		resp, err := rn.API.Deployment().Errors(context.Background(), &req)
+		if err != nil {
+			return err
+		}
+		return rn.print(resp)
+	case "get":
+		// Intercept -h before parsing: the leaf flag set is ExitOnError, so passing
+		// -h to Parse would os.Exit rather than render through Usage.
+		f := rn.subFlagSet("deployment", "errors get")
+		if len(rest) > 0 && IsHelpArg(rest[0]) {
+			f.Usage()
+			return nil
+		}
+		var req api.DeploymentErrorGet
+		f.StringVar(&req.Location, "location", "", "location")
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Name, "name", "", "deployment name")
+		f.StringVar(&req.ID, "id", "", "error issue id")
+		f.Parse(rest)
+		resp, err := rn.API.Deployment().ErrorGet(context.Background(), &req)
+		if err != nil {
+			return err
+		}
+		// In table mode print the issue summary, then the sample stack and recent
+		// occurrences, which the result's Table() (a flat summary) omits. Other
+		// output modes (yaml/json) carry the full struct already.
+		if rn.OutputMode == "" || rn.OutputMode == "table" {
+			return rn.printErrorIssueDetail(resp)
+		}
+		return rn.print(resp)
+	case "update":
+		f := rn.subFlagSet("deployment", "errors update")
+		if len(rest) > 0 && IsHelpArg(rest[0]) {
+			f.Usage()
+			return nil
+		}
+		var req api.DeploymentErrorUpdate
+		f.StringVar(&req.Location, "location", "", "location")
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Name, "name", "", "deployment name")
+		f.StringVar(&req.ID, "id", "", "error issue id")
+		f.StringVar(&req.Status, "status", "", "new triage status: resolved, open (reopen), or muted")
+		f.Parse(rest)
+		resp, err := rn.API.Deployment().ErrorUpdate(context.Background(), &req)
+		if err != nil {
+			return err
+		}
+		return rn.print(resp)
+	}
+}
+
+// printErrorIssueDetail renders an error issue's full detail in table mode: the
+// summary (from the result's Table()), then the representative stack trace and
+// the recent occurrence pointers that deep-link back into logs history.
+func (rn Runner) printErrorIssueDetail(resp *api.DeploymentErrorGetResult) error {
+	rn.printTable(resp.Table())
+
+	out := rn.output()
+	i := resp.Issue
+	if i.SampleMessage != "" {
+		fmt.Fprintf(out, "\nSample:\n%s\n", i.SampleMessage)
+	}
+	if len(i.RecentEvents) > 0 {
+		fmt.Fprint(out, "\nRecent occurrences:\n")
+		table := [][]string{{"TIMESTAMP", "POD", "OBJECT", "OFFSET"}}
+		for _, e := range i.RecentEvents {
+			ts := ""
+			if !e.Timestamp.IsZero() {
+				ts = e.Timestamp.UTC().Format(time.RFC3339)
+			}
+			table = append(table, []string{ts, e.Pod, e.Object, strconv.Itoa(e.Offset)})
+		}
+		rn.printTable(table)
+	}
+	return nil
 }
 
 func (rn Runner) disk(args ...string) error {


### PR DESCRIPTION
PR **6/7** of the error-detection feature (`SPEC-error-detection.md`).

Exposes the already-shipped `deployment.errors*` API through the CLI as a `deployment errors` sub-group, mirroring the existing custom flag-based command framework (nested under `deployment` like `set`/`set image`).

## Commands added

- `deploys deployment errors` (list) — lists detected application error issues (grouped, deduplicated stack traces mined from the durable log stream). Flags: `-project`, `-location`, `-name`, `-status open|resolved|muted|all` (default open), `-sort lastSeen|firstSeen|count`, `-limit`, `-cursor`. Calls `Deployment().Errors`.
- `deploys deployment errors get -id <id>` — shows one issue with its representative stack trace and recent occurrence pointers. Calls `Deployment().ErrorGet`. In table mode prints the issue summary, then the sample stack and a `Recent occurrences` table (the result `Table()` is a flat summary, so the detail is rendered explicitly); yaml/json carry the full struct.
- `deploys deployment errors update -id <id> -status resolved|open|muted` — resolve, reopen, or mute an issue. Calls `Deployment().ErrorUpdate`.

The bare `errors` invocation dispatches to list (the SPEC reads `errors` as list/get/resolve). The help registry carries the user-facing `errors` listing plus hidden `errors get`/`errors update` leaves that back their `-h` banners. `errors`/`errors get`/`errors update` `-h` render without resolving credentials or hitting the API.

Also documents the sub-group in the README's `deployment` section.

## Dependency

api pinned to `@main` for the `deployment.errors*` contract (`Errors`/`ErrorGet`/`ErrorUpdate` + types).

## Verification

This repo has **no PR CI**, so verified locally:

- `GOFLAGS=-mod=mod go build ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — 28 passed (added `isFlag` unit test + `errors` help-path coverage)
- `gofmt -l` — clean
- Smoke-checked `deployment errors -h`, `errors get -h`, `errors update -h`, `errors list -h`, unknown-leaf error, and the live dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011d4bVuGLnCbcJD9ZvastPH