### PR TITLE
error: add error command group (list/get/update/report)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/deploys-app/deploys
 go 1.26
 
 require (
-	github.com/deploys-app/api v0.0.0-20260621150607-e5355f6b1083
+	github.com/deploys-app/api v0.0.0-20260621155632-5f0dc635e4b7
 	golang.org/x/mod v0.37.0
 	golang.org/x/oauth2 v0.14.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/deploys-app/deploys
 go 1.26
 
 require (
-	github.com/deploys-app/api v0.0.0-20260621114444-0ba48f38fbb7
+	github.com/deploys-app/api v0.0.0-20260621150607-e5355f6b1083
 	golang.org/x/mod v0.37.0
 	golang.org/x/oauth2 v0.14.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:W
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deploys-app/api v0.0.0-20260621150607-e5355f6b1083 h1:aqhXkCNJ3MK+TqBeq0s+kQ7tHFJ9/KYjHD0mIUuhA8E=
-github.com/deploys-app/api v0.0.0-20260621150607-e5355f6b1083/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
+github.com/deploys-app/api v0.0.0-20260621155632-5f0dc635e4b7 h1:qWIVKuGCm1U2cLGoyzTl1P/tNh94s7Ed+OjEcVh/1OI=
+github.com/deploys-app/api v0.0.0-20260621155632-5f0dc635e4b7/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:W
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deploys-app/api v0.0.0-20260621114444-0ba48f38fbb7 h1:bRMPkkBkomba2/SPI1MzEizrTd+FQpImAnfnb9vcXNc=
-github.com/deploys-app/api v0.0.0-20260621114444-0ba48f38fbb7/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
+github.com/deploys-app/api v0.0.0-20260621150607-e5355f6b1083 h1:aqhXkCNJ3MK+TqBeq0s+kQ7tHFJ9/KYjHD0mIUuhA8E=
+github.com/deploys-app/api v0.0.0-20260621150607-e5355f6b1083/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/internal/runner/error.go
+++ b/internal/runner/error.go
@@ -1,0 +1,126 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/deploys-app/api"
+)
+
+// errorGroup handles the top-level `error` command group, backed by the
+// `error.*` API resource (api.Errors): grouped, deduplicated application-error
+// issues with a triage lifecycle. It mirrors the flat-group pattern (see cache,
+// disk): IsHelpArg → group usage, subFlagSet per leaf, rn.print(resp).
+func (rn Runner) errorGroup(args ...string) error {
+	if len(args) == 0 || IsHelpArg(args[0]) {
+		return rn.groupUsage("error")
+	}
+
+	s := rn.API.Errors()
+
+	var (
+		resp any
+		err  error
+	)
+
+	f := rn.subFlagSet("error", args[0])
+	switch args[0] {
+	default:
+		return rn.unknownSub("error", args[0])
+	case "list":
+		var req api.ErrorList
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Location, "location", "", "location (optional; narrows a project-wide listing, required when -name is set)")
+		f.StringVar(&req.Name, "name", "", "deployment name (omit to list issues across the whole project)")
+		f.StringVar(&req.Status, "status", "", "triage status filter: open (default), resolved, muted, all")
+		f.StringVar(&req.Sort, "sort", "", "sort order: lastSeen (default), firstSeen, count")
+		f.IntVar(&req.Limit, "limit", 0, "max issues per page (default 50, max 200)")
+		f.StringVar(&req.Cursor, "cursor", "", "opaque page cursor from a previous response's nextCursor")
+		f.Parse(args[1:])
+		resp, err = s.List(context.Background(), &req)
+	case "get":
+		var req api.ErrorGet
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Location, "location", "", "location")
+		f.StringVar(&req.Name, "name", "", "deployment name")
+		f.StringVar(&req.ID, "id", "", "error issue id")
+		f.Parse(args[1:])
+		got, gerr := s.Get(context.Background(), &req)
+		if gerr != nil {
+			return gerr
+		}
+		// In table mode print the issue summary, then the sample stack and recent
+		// occurrences, which the result's flat Table() omits. Other output modes
+		// (yaml/json) carry the full struct already, so fall through to print.
+		if rn.OutputMode == "" || rn.OutputMode == "table" {
+			return rn.printErrorIssueDetail(got)
+		}
+		resp = got
+	case "update":
+		var req api.ErrorUpdate
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Location, "location", "", "location")
+		f.StringVar(&req.Name, "name", "", "deployment name")
+		f.StringVar(&req.ID, "id", "", "error issue id")
+		f.StringVar(&req.Status, "status", "", "new triage status: resolved, open (reopen), or muted")
+		f.Parse(args[1:])
+		resp, err = s.Update(context.Background(), &req)
+	case "report":
+		// report sends a single, minimal error event (one ErrorReport in Events).
+		// Frames are optional — omitting them fingerprints by Type alone, which is
+		// fine for a hand-reported error.
+		var (
+			req                           api.ErrorCreate
+			kind, typ, title, sample, pod string
+		)
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Location, "location", "", "location")
+		f.StringVar(&req.Name, "name", "", "deployment name")
+		f.StringVar(&typ, "type", "", "exception/panic class, e.g. TypeError or panic (required)")
+		f.StringVar(&kind, "kind", "", "language/runtime family: go, java, python, node, ruby, generic (default generic)")
+		f.StringVar(&title, "title", "", "optional display line (type + first message)")
+		f.StringVar(&sample, "sample", "", "optional full stack-trace text")
+		f.StringVar(&pod, "pod", "", "reporting instance/host (default \"reported\")")
+		f.Parse(args[1:])
+		req.Events = []api.ErrorReport{{
+			Kind:   kind,
+			Type:   typ,
+			Title:  title,
+			Sample: sample,
+			Pod:    pod,
+		}}
+		resp, err = s.Create(context.Background(), &req)
+	}
+	if err != nil {
+		return err
+	}
+	return rn.print(resp)
+}
+
+// printErrorIssueDetail renders an error issue's full detail in table mode: the
+// summary (from the result's Table()), then the representative stack trace and
+// the recent occurrence pointers that deep-link back into logs history.
+func (rn Runner) printErrorIssueDetail(resp *api.ErrorGetResult) error {
+	rn.printTable(resp.Table())
+
+	out := rn.output()
+	i := resp.Issue
+	if i.SampleMessage != "" {
+		fmt.Fprintf(out, "\nSample:\n%s\n", i.SampleMessage)
+	}
+	if len(i.RecentEvents) > 0 {
+		fmt.Fprint(out, "\nRecent occurrences:\n")
+		table := [][]string{{"TIMESTAMP", "POD", "OBJECT", "OFFSET"}}
+		for _, e := range i.RecentEvents {
+			ts := ""
+			if !e.Timestamp.IsZero() {
+				ts = e.Timestamp.UTC().Format(time.RFC3339)
+			}
+			table = append(table, []string{ts, e.Pod, e.Object, strconv.Itoa(e.Offset)})
+		}
+		rn.printTable(table)
+	}
+	return nil
+}

--- a/internal/runner/help.go
+++ b/internal/runner/help.go
@@ -134,12 +134,17 @@ var commands = []command{
 			// backs its banner. They share wording so the listing and banner agree.
 			{name: "set", short: "roll out a new image (set image <name> -image <ref>)"},
 			{name: "set image", args: "<name> -image <ref>", short: "roll out a new image for a deployment", hidden: true},
-			// "errors" is the user-facing listing for the error-issue sub-group; the
-			// bare invocation lists issues, while "errors get"/"errors update" are
-			// hidden leaves that back their own banners (mirroring "set"/"set image").
-			{name: "errors", args: "[-status open|resolved|muted|all] [-sort lastSeen|firstSeen|count] [-limit n] [-cursor c]", short: "list detected application error issues (get/update an issue by id)"},
-			{name: "errors get", args: "-id <id>", short: "show an error issue with its sample stack and recent occurrences", hidden: true},
-			{name: "errors update", args: "-id <id> -status resolved|open|muted", short: "change an error issue's triage status (resolve, reopen, or mute)", hidden: true},
+		},
+	},
+	{
+		name:    "error",
+		aliases: []string{"errors"},
+		short:   "detected application error issues (Sentry-lite)",
+		subs: []subcommand{
+			{name: "list", args: "[-name <deployment>] [-status open|resolved|muted|all] [-sort lastSeen|firstSeen|count] [-limit n] [-cursor c]", short: "list error issues (omit -name for a project-wide view)"},
+			{name: "get", args: "-name <deployment> -id <id>", short: "show an error issue with its sample stack and recent occurrences"},
+			{name: "update", args: "-name <deployment> -id <id> -status resolved|open|muted", short: "change an error issue's triage status (resolve, reopen, or mute)"},
+			{name: "report", args: "-name <deployment> -type <class> [-kind] [-title] [-sample]", short: "report a single application error directly"},
 		},
 	},
 	{

--- a/internal/runner/help_test.go
+++ b/internal/runner/help_test.go
@@ -121,10 +121,10 @@ func TestRunHelpNeedsNoAPI(t *testing.T) {
 		{[]string{"me"}, "Subcommands:"},
 		{[]string{"me", "help"}, "identity and access"},
 		{[]string{"d", "-h"}, "deployments and their lifecycle"},
-		// the deployment errors sub-group renders its own banners without an API
-		{[]string{"deployment", "errors", "-h"}, "list detected application error issues"},
-		{[]string{"deployment", "errors", "get", "-h"}, "Usage: deploys deployment errors get"},
-		{[]string{"deployment", "errors", "update", "-h"}, "change an error issue's triage status"},
+		// the error group and its aliases render help without an API
+		{[]string{"error"}, "Subcommands:"},
+		{[]string{"error", "help"}, "detected application error issues"},
+		{[]string{"errors", "-h"}, "detected application error issues"},
 	}
 	for _, tc := range cases {
 		if err := tmp.Truncate(0); err != nil {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strconv"
 	"time"
 	"unicode/utf8"
 
@@ -117,6 +116,8 @@ func (rn Runner) Run(args ...string) error {
 		return rn.role(args[1:]...)
 	case "deployment", "deploy", "d":
 		return rn.deployment(args[1:]...)
+	case "error", "errors":
+		return rn.errorGroup(args[1:]...)
 	case "domain":
 		return rn.domain(args[1:]...)
 	case "route":
@@ -402,15 +403,15 @@ func (rn Runner) deployment(args ...string) error {
 		return rn.groupUsage("deployment")
 	}
 
-	// deploy, set, and errors own their flag handling (including -h); the shared
-	// subFlagSet below is only for the simple lifecycle subcommands.
+	// deploy and set own their flag handling (including -h); the shared
+	// subFlagSet below is only for the simple lifecycle subcommands. Error issues
+	// now live in their own top-level `error` group (backed by the api `error.*`
+	// resource), no longer under `deployment errors`.
 	switch args[0] {
 	case "deploy":
 		return rn.deploymentDeploy(args[1:]...)
 	case "set":
 		return rn.deploymentSet(args[1:]...)
-	case "errors":
-		return rn.deploymentErrors(args[1:]...)
 	}
 
 	s := rn.API.Deployment()
@@ -899,130 +900,6 @@ func (rn Runner) deploymentSet(args ...string) error {
 		}
 		return rn.print(resp)
 	}
-}
-
-// deploymentErrors handles the `deployment errors` sub-group: list (the bare
-// `errors` invocation), get, and update. The bare form lists open issues —
-// mirroring how `deployment errors` reads in the SPEC (list/get/resolve) — so a
-// flagless `deployment errors` does something useful rather than printing usage.
-func (rn Runner) deploymentErrors(args ...string) error {
-	// The bare `errors` form (and any leading flag) is the list; only get and
-	// update are addressed by an explicit subcommand keyword. Resolve the leaf and
-	// its help intent before touching the API, so `errors -h` (and each leaf's -h)
-	// renders without resolving credentials or panicking on a nil API.
-	//
-	// `errors -h`/`errors help`/`errors --help` shows the list banner (the group's
-	// primary action, which lists its own flags). Checked before the isFlag routing
-	// below because -h/--help look like flags but mean "help here", not "list with
-	// this flag".
-	if len(args) > 0 && IsHelpArg(args[0]) {
-		f := rn.subFlagSet("deployment", "errors")
-		f.Usage()
-		return nil
-	}
-
-	leaf := "list"
-	rest := args
-	if len(args) > 0 && !isFlag(args[0]) {
-		leaf = args[0]
-		rest = args[1:]
-	}
-
-	switch leaf {
-	default:
-		return rn.unknownSub("deployment errors", leaf)
-	case "list":
-		var (
-			req    api.DeploymentErrors
-			status string
-			sort   string
-		)
-		f := rn.subFlagSet("deployment", "errors")
-		f.StringVar(&req.Location, "location", "", "location")
-		f.StringVar(&req.Project, "project", "", "project id")
-		f.StringVar(&req.Name, "name", "", "deployment name")
-		f.StringVar(&status, "status", "", "triage status filter: open (default), resolved, muted, all")
-		f.StringVar(&sort, "sort", "", "sort order: lastSeen (default), firstSeen, count")
-		f.IntVar(&req.Limit, "limit", 0, "max issues per page (default 50, max 200)")
-		f.StringVar(&req.Cursor, "cursor", "", "opaque page cursor from a previous response's nextCursor")
-		f.Parse(rest)
-		req.Status = status
-		req.Sort = sort
-		resp, err := rn.API.Deployment().Errors(context.Background(), &req)
-		if err != nil {
-			return err
-		}
-		return rn.print(resp)
-	case "get":
-		// Intercept -h before parsing: the leaf flag set is ExitOnError, so passing
-		// -h to Parse would os.Exit rather than render through Usage.
-		f := rn.subFlagSet("deployment", "errors get")
-		if len(rest) > 0 && IsHelpArg(rest[0]) {
-			f.Usage()
-			return nil
-		}
-		var req api.DeploymentErrorGet
-		f.StringVar(&req.Location, "location", "", "location")
-		f.StringVar(&req.Project, "project", "", "project id")
-		f.StringVar(&req.Name, "name", "", "deployment name")
-		f.StringVar(&req.ID, "id", "", "error issue id")
-		f.Parse(rest)
-		resp, err := rn.API.Deployment().ErrorGet(context.Background(), &req)
-		if err != nil {
-			return err
-		}
-		// In table mode print the issue summary, then the sample stack and recent
-		// occurrences, which the result's Table() (a flat summary) omits. Other
-		// output modes (yaml/json) carry the full struct already.
-		if rn.OutputMode == "" || rn.OutputMode == "table" {
-			return rn.printErrorIssueDetail(resp)
-		}
-		return rn.print(resp)
-	case "update":
-		f := rn.subFlagSet("deployment", "errors update")
-		if len(rest) > 0 && IsHelpArg(rest[0]) {
-			f.Usage()
-			return nil
-		}
-		var req api.DeploymentErrorUpdate
-		f.StringVar(&req.Location, "location", "", "location")
-		f.StringVar(&req.Project, "project", "", "project id")
-		f.StringVar(&req.Name, "name", "", "deployment name")
-		f.StringVar(&req.ID, "id", "", "error issue id")
-		f.StringVar(&req.Status, "status", "", "new triage status: resolved, open (reopen), or muted")
-		f.Parse(rest)
-		resp, err := rn.API.Deployment().ErrorUpdate(context.Background(), &req)
-		if err != nil {
-			return err
-		}
-		return rn.print(resp)
-	}
-}
-
-// printErrorIssueDetail renders an error issue's full detail in table mode: the
-// summary (from the result's Table()), then the representative stack trace and
-// the recent occurrence pointers that deep-link back into logs history.
-func (rn Runner) printErrorIssueDetail(resp *api.DeploymentErrorGetResult) error {
-	rn.printTable(resp.Table())
-
-	out := rn.output()
-	i := resp.Issue
-	if i.SampleMessage != "" {
-		fmt.Fprintf(out, "\nSample:\n%s\n", i.SampleMessage)
-	}
-	if len(i.RecentEvents) > 0 {
-		fmt.Fprint(out, "\nRecent occurrences:\n")
-		table := [][]string{{"TIMESTAMP", "POD", "OBJECT", "OFFSET"}}
-		for _, e := range i.RecentEvents {
-			ts := ""
-			if !e.Timestamp.IsZero() {
-				ts = e.Timestamp.UTC().Format(time.RFC3339)
-			}
-			table = append(table, []string{ts, e.Pod, e.Object, strconv.Itoa(e.Offset)})
-		}
-		rn.printTable(table)
-	}
-	return nil
 }
 
 func (rn Runner) disk(args ...string) error {


### PR DESCRIPTION
## What

Adds a top-level `error` command group (aliased `errors`) to the deploys CLI, backed by the new api `error.*` resource (`api.Errors`):

- `deploys error list --project P [--location L] [--name N] [--status open|resolved|muted|all] [--sort lastSeen|firstSeen|count] [--limit n] [--cursor c]` → `error.list`; omit `--name` for a project-wide view. Prints the result table.
- `deploys error get --project P --location L --name N --id ID` → `error.get`. Table mode prints the issue summary plus its sample stack trace and recent occurrences; yaml/json carry the full struct.
- `deploys error update --project P --location L --name N --id ID --status resolved|open|muted` → `error.update`.
- `deploys error report --project P --location L --name N --type TYPE [--kind go|java|python|node|ruby|generic] [--title T] [--sample S] [--pod P]` → `error.create` with a single minimal `ErrorReport` (frames omitted). Prints the returned issue ref(s).

Mirrors the existing flat-group pattern (cache, disk): `subFlagSet` per leaf, server-side `Valid()` for required-flag / enum validation, `rn.print(resp)`.

## Why the diff also removes `deployment errors`

The pinned api (**deploys-app/api#106**) replaces the old `deployment.errors` surface with the standalone `error.*` resource, so `api.DeploymentErrors` / `DeploymentErrorGet` / `DeploymentErrorUpdate` and `Deployment().Errors/ErrorGet/ErrorUpdate` no longer exist in the client. The previous `deployment errors` sub-group therefore can't compile against the pin. This PR migrates it to the new group: it drops the dead sub-group from the deployment dispatch + help registry and ports its table-mode issue-detail rendering (sample stack + recent occurrences) into `error get`.

## API pin

Pinned to `github.com/deploys-app/api@e5355f6` (the `error.*` module on the api `error-module` branch, deploys-app/api#106). **Re-pin to `api/main` once #106 merges.**

## Verification

This repo has **no PR CI**, so verified locally:

- `go build ./...` — success
- `go vet ./...` — no issues
- `go test ./...` — 28 passed (updated `TestRunHelpNeedsNoAPI` for the new `error` group help paths)
- Manually traced each leaf's flag wiring and `-h` banner from the built binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011d4bVuGLnCbcJD9ZvastPH