### PR TITLE
Preview environments: site preview + deployment extend-ttl

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/deploys-app/deploys
 go 1.26
 
 require (
-	github.com/deploys-app/api v0.0.0-20260621155632-5f0dc635e4b7
+	github.com/deploys-app/api v0.0.0-20260622050348-95d28f356073
 	golang.org/x/mod v0.37.0
 	golang.org/x/oauth2 v0.14.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:W
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deploys-app/api v0.0.0-20260621155632-5f0dc635e4b7 h1:qWIVKuGCm1U2cLGoyzTl1P/tNh94s7Ed+OjEcVh/1OI=
-github.com/deploys-app/api v0.0.0-20260621155632-5f0dc635e4b7/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
+github.com/deploys-app/api v0.0.0-20260622050348-95d28f356073 h1:q+01NmuYelWKka00FvbXamL5SFbWBJEckeY7Gr+eFag=
+github.com/deploys-app/api v0.0.0-20260622050348-95d28f356073/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/internal/runner/help.go
+++ b/internal/runner/help.go
@@ -130,6 +130,7 @@ var commands = []command{
 			{name: "metrics", args: "[-time-range 1h|6h|12h|1d]", short: "show deployment metrics"},
 			{name: "status", short: "show pod health and failure reasons"},
 			{name: "logs", args: "[-pod p] [-previous] [-tail n] [-follow]", short: "read a bounded snapshot of recent container logs"},
+			{name: "extend-ttl", args: "-name n -ttl s", short: "re-stamp a preview's auto-delete window to now+ttl (keep-alive)"},
 			// "set" is the user-facing listing; "set image" is the hidden leaf that
 			// backs its banner. They share wording so the listing and banner agree.
 			{name: "set", short: "roll out a new image (set image <name> -image <ref>)"},
@@ -306,6 +307,7 @@ var commands = []command{
 		short: "publish static sites from the local filesystem",
 		subs: []subcommand{
 			{name: "publish", args: "-name -dir <path> [-environment -spa -notFound]", short: "publish a static site from a local directory"},
+			{name: "preview", args: "-name -dir <path> [-ttl s] [-force] [-environment -spa -notFound]", short: "publish and deploy a throwaway preview (auto-deletes at ttl; -force to overwrite a non-preview)"},
 		},
 	},
 	{

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -543,6 +543,14 @@ func (rn Runner) deployment(args ...string) error {
 			return fmt.Errorf("invalid -until: %w", err)
 		}
 		resp, err = s.LogsHistory(context.Background(), &req)
+	case "extend-ttl", "extendTTL":
+		var req api.DeploymentExtendTTL
+		f.StringVar(&req.Location, "location", "", "location")
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.Name, "name", "", "deployment name")
+		f.Int64Var(&req.TTL, "ttl", 0, "seconds from now until auto-delete (must be > 0)")
+		f.Parse(args[1:])
+		resp, err = s.ExtendTTL(context.Background(), &req)
 	}
 	if err != nil {
 		return err

--- a/internal/runner/site.go
+++ b/internal/runner/site.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/deploys-app/api"
 	"github.com/deploys-app/api/client"
 )
 
@@ -39,5 +40,81 @@ func (rn Runner) site(args ...string) error {
 			return err
 		}
 		return rn.print(res)
+	case "preview":
+		// preview wraps publish → deploy(ttl) → get into one throwaway-preview
+		// step: it publishes the local directory, deploys it as a TTL'd Static
+		// deployment, and prints the resulting deployment (url + releaseUrl +
+		// expiresAt). It auto-deletes at the TTL; `deployment extend-ttl` keeps it
+		// alive and `deployment delete` drops it early.
+		var (
+			opts     client.SitePublishOptions
+			location string
+			ttl      int64
+			force    bool
+		)
+		f.StringVar(&opts.Project, "project", "", "project id")
+		f.StringVar(&opts.Name, "name", "", "deployment name")
+		f.StringVar(&opts.Dir, "dir", ".", "local directory to publish")
+		f.StringVar(&location, "location", "", "location")
+		// Default to a non-production environment so the preview is served
+		// X-Robots-Tag: noindex (the gateway only omits noindex for production).
+		f.StringVar(&opts.Environment, "environment", "preview", "release environment (non-production previews are served noindex)")
+		f.BoolVar(&opts.SPA, "spa", false, "serve index.html for unmatched paths (single-page app)")
+		f.StringVar(&opts.NotFound, "notFound", "", "custom 404 document path (e.g. 404.html)")
+		f.Int64Var(&ttl, "ttl", 7200, "seconds until the preview auto-deletes (0 = no auto-delete)")
+		f.BoolVar(&force, "force", false, "overwrite an existing non-preview (production) deployment of the same name")
+		f.Parse(args[1:])
+
+		c, ok := rn.API.(*client.Client)
+		if !ok {
+			return fmt.Errorf("site preview requires the default api client")
+		}
+
+		// Safety: a throwaway preview must not silently convert an existing
+		// non-preview (production) deployment into an auto-deleting one. If the
+		// target already exists and has no TTL, refuse unless -force. Fail open on
+		// any lookup error (not-found, forbidden, etc.) so the guard never blocks a
+		// legitimate preview — it only trips on a clean "exists and is permanent".
+		if !force {
+			if existing, gerr := c.Deployment().Get(context.Background(), &api.DeploymentGet{
+				Project:  opts.Project,
+				Location: location,
+				Name:     opts.Name,
+			}); gerr == nil && existing.TTL == 0 {
+				return fmt.Errorf("deployment %q already exists and is not a preview (no ttl); pass -force to overwrite it as a throwaway preview", opts.Name)
+			}
+		}
+
+		// 1. Publish the local directory → a content-addressed site ref.
+		pub, err := c.PublishSite(context.Background(), &opts)
+		if err != nil {
+			return err
+		}
+
+		// 2. Deploy it as a TTL'd Static preview.
+		deploy := &api.DeploymentDeploy{
+			Project:  opts.Project,
+			Location: location,
+			Name:     opts.Name,
+			Type:     api.DeploymentTypeStatic,
+			Site:     pub.SiteRef,
+		}
+		if ttl > 0 {
+			deploy.TTL = &ttl
+		}
+		if _, err := c.Deployment().Deploy(context.Background(), deploy); err != nil {
+			return err
+		}
+
+		// 3. Read back the rolling url, the immutable releaseUrl, and expiresAt.
+		got, err := c.Deployment().Get(context.Background(), &api.DeploymentGet{
+			Project:  opts.Project,
+			Location: location,
+			Name:     opts.Name,
+		})
+		if err != nil {
+			return err
+		}
+		return rn.print(got)
 	}
 }


### PR DESCRIPTION
CLI surface for **Preview Environments** (`SPEC-preview-environments.md` §D). Consumes the api contract (deploys-app/api#107).

## What's in this PR
- **`deploys site preview`** — one-step throwaway preview: publishes the local directory (defaulting to a non-production `preview` environment so it's served `noindex`), deploys it as a TTL'd Static deployment (default 2h), and prints the deployment (`url` + `releaseUrl` + `expiresAt`).
- **`deploys deployment extend-ttl -name n -ttl s`** — re-stamp a preview's auto-delete window to `now + ttl` without redeploying (keep-alive).

`releaseUrl`/`expiresAt` already surface in `deployment get`/`list` output via the `api.DeploymentItem` contract — no printer change needed.

This repo has no PR CI; verified locally (`go build`/`go vet`/`go test ./...` green, help output checked).

Depends on deploys-app/api#107 (pinned to its branch commit; re-pin to `api/main` after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYMGjvqWELm2ctgKamiMSS