### PR TITLE
Refresh me generate-token allowed-permission help

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -201,7 +201,7 @@ func (rn Runner) me(args ...string) error {
 			permissions string
 		)
 		f.StringVar(&req.Project, "project", "", "project id")
-		f.StringVar(&permissions, "permissions", "", "permissions (comma separated; allowed: dropbox.upload, site.publish)")
+		f.StringVar(&permissions, "permissions", "", "permissions (comma separated; allowed: dropbox.upload, site.publish, deployment.deploy, deployment.get, deployment.logs, error.create, error.list, error.get)")
 		f.IntVar(&req.TTLSeconds, "ttl", 0, "token lifetime in seconds (60-3600, default 900)")
 		f.Parse(args[1:])
 		req.Permissions = splitComma(permissions)


### PR DESCRIPTION
The `deploys me generate-token -permissions` help listed only `dropbox.upload, site.publish`, but the api's `GenerateTokenPermissions` allowlist now also includes `deployment.get`, `deployment.logs`, `deployment.deploy` (preview environments), and `error.create`/`error.list`/`error.get`. Updated to list the full allowed set so the scoped-token preview flow is discoverable from `-h`.

Help-text only; no behavior change. Build + tests green. (Repo has no PR CI; verified locally.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYMGjvqWELm2ctgKamiMSS