### PR TITLE
feat(route): add -host flag to route create

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/deploys-app/deploys
 go 1.26
 
 require (
-	github.com/deploys-app/api v0.0.0-20260622050348-95d28f356073
+	github.com/deploys-app/api v0.0.0-20260622233547-73aab4f64e32
 	golang.org/x/mod v0.37.0
 	golang.org/x/oauth2 v0.14.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:W
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deploys-app/api v0.0.0-20260622050348-95d28f356073 h1:q+01NmuYelWKka00FvbXamL5SFbWBJEckeY7Gr+eFag=
-github.com/deploys-app/api v0.0.0-20260622050348-95d28f356073/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
+github.com/deploys-app/api v0.0.0-20260622233547-73aab4f64e32 h1:kZ8Udzs+1vcMklDFq45bxL03ZE2JVf+enXYyIpszhgA=
+github.com/deploys-app/api v0.0.0-20260622233547-73aab4f64e32/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/internal/runner/help.go
+++ b/internal/runner/help.go
@@ -163,7 +163,7 @@ var commands = []command{
 		name:  "route",
 		short: "HTTP routes mapping a domain/path to a target",
 		subs: []subcommand{
-			{name: "create", args: "-domain -path (-target <t> | -deployment <name>)", short: "create a route"},
+			{name: "create", args: "-domain -path (-target <t> | -deployment <name>) [-host <h>]", short: "create a route"},
 			{name: "get", args: "-domain -path", short: "show a route"},
 			{name: "list", short: "list routes"},
 			{name: "delete", args: "-domain -path", short: "delete a route"},

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -646,6 +646,7 @@ func (rn Runner) route(args ...string) error {
 		f.StringVar(&req.Path, "path", "", "path")
 		f.StringVar(&req.Target, "target", "", "target (for v2)")
 		f.StringVar(&deployment, "deployment", "", "deployment name (for v1)")
+		f.StringVar(&req.Config.Host, "host", "", "override the Host header sent upstream (external http:// targets only)")
 		f.Parse(args[1:])
 
 		if req.Target == "" && deployment != "" {


### PR DESCRIPTION
## What

Add a `-host` flag to `deploys route create`, setting `RouteConfig.Host` — the upstream Host-header override for an **external `http://` route** whose backend virtual-hosts on Host. The api rejects host on non-external targets.

## Changes
- `-host` flag on `route create`; help text updated.
- Bumps `github.com/deploys-app/api`.

---
Builds on **deploys-app/api#108** (✅ merged); pinned to api/main `73aab4f`.
