### PR TITLE
feat(me): widen generate-token + add list-tokens/revoke-token

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/deploys-app/deploys
 go 1.26
 
 require (
-	github.com/deploys-app/api v0.0.0-20260622050348-95d28f356073
+	github.com/deploys-app/api v0.0.0-20260622221324-4141c6c241d5
 	golang.org/x/mod v0.37.0
 	golang.org/x/oauth2 v0.14.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:W
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deploys-app/api v0.0.0-20260622050348-95d28f356073 h1:q+01NmuYelWKka00FvbXamL5SFbWBJEckeY7Gr+eFag=
-github.com/deploys-app/api v0.0.0-20260622050348-95d28f356073/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
+github.com/deploys-app/api v0.0.0-20260622221324-4141c6c241d5 h1:MEllX25HEINDIrrP4IRR4vW8cBcsJhrhQaT8J2InSqk=
+github.com/deploys-app/api v0.0.0-20260622221324-4141c6c241d5/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/internal/runner/help.go
+++ b/internal/runner/help.go
@@ -57,7 +57,9 @@ var commands = []command{
 			{name: "get", short: "show the current authenticated identity"},
 			{name: "authorized", args: "-project p -permissions a,b", short: "check whether you hold the given permissions in a project"},
 			{name: "permissions", args: "-project p", short: "list your effective permissions in a project"},
-			{name: "generate-token", aliases: []string{"generateToken"}, args: "-project p -permissions a,b [-ttl 900]", short: "mint a short-lived, scope-limited bearer token"},
+			{name: "generate-token", aliases: []string{"generateToken"}, args: "-project p -permissions a,b [-ttl 900] [-label l]", short: "mint a short-lived, scope-limited bearer token"},
+			{name: "list-tokens", aliases: []string{"listTokens"}, args: "-project p", short: "list your active scoped tokens for a project"},
+			{name: "revoke-token", aliases: []string{"revokeToken"}, args: "-project p -id t", short: "revoke one of your scoped tokens by id"},
 		},
 	},
 	{

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -201,11 +201,23 @@ func (rn Runner) me(args ...string) error {
 			permissions string
 		)
 		f.StringVar(&req.Project, "project", "", "project id")
-		f.StringVar(&permissions, "permissions", "", "permissions (comma separated; allowed: dropbox.upload, site.publish, deployment.deploy, deployment.get, deployment.logs, error.create, error.list, error.get)")
+		f.StringVar(&permissions, "permissions", "", "permissions (comma separated; any you hold except wildcards and role.*/serviceaccount.key.*/billing.*/pullsecret.get)")
 		f.IntVar(&req.TTLSeconds, "ttl", 0, "token lifetime in seconds (60-3600, default 900)")
+		f.StringVar(&req.Label, "label", "", "optional attribution label for the agent session (e.g. claude-code:pr-42)")
 		f.Parse(args[1:])
 		req.Permissions = splitComma(permissions)
 		resp, err = s.GenerateToken(context.Background(), &req)
+	case "list-tokens", "listTokens":
+		var req api.MeListTokens
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.Parse(args[1:])
+		resp, err = s.ListTokens(context.Background(), &req)
+	case "revoke-token", "revokeToken":
+		var req api.MeRevokeToken
+		f.StringVar(&req.Project, "project", "", "project id")
+		f.StringVar(&req.ID, "id", "", "scoped token id (from list-tokens)")
+		f.Parse(args[1:])
+		resp, err = s.RevokeToken(context.Background(), &req)
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
CLI surface for **SPEC-agent-identity** (A5). Depends on deploys-app/api#109 (re-pinned here).

- `me generate-token` — permissions help no longer lists a fixed allowlist (it states the delegation rule: any held permission except wildcards and `role.*`/`serviceaccount.key.*`/`billing.*`/`pullsecret.get`); adds `--label`.
- `me list-tokens --project p` — list your active scoped tokens (id, label, permissions, expiry).
- `me revoke-token --project p --id tok_…` — revoke one early.
- Help registry updated; `TestRegistryDescriptions` (help⇄dispatch sync) green. `go build`/`vet`/`test` pass. (Repo has no PR CI — verified locally.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9FhPEapaKr4VugQBEdisj