### PR TITLE
feat(auth): add `deploys login` with multi-account support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,18 +32,55 @@ specific release, and `nightly` tracks the newest `master` build.
 
 ## Authentication
 
-The CLI resolves credentials in this order:
+For interactive use, sign in once with your browser:
+
+```bash
+deploys login          # opens a browser, stores the account, makes it active
+deploys auth status    # show the credential in effect and its expiry
+deploys logout         # revoke and remove the active account
+```
+
+`login` runs an OAuth Authorization Code + PKCE flow against `auth.deploys.app`
+(a loopback redirect on `127.0.0.1`), then stores the resulting bearer token —
+keyed by `(endpoint, email)` — in a `0600` file under your config dir
+(`$DEPLOYS_CONFIG_DIR`, else `$XDG_CONFIG_HOME/deploys`, else the OS config dir).
+Tokens last **7 days and cannot be refreshed**: when one expires the CLI exits
+with code **4** and asks you to run `deploys login` again.
+
+### Multiple accounts
+
+```bash
+deploys auth list                      # all stored accounts, grouped by endpoint
+deploys auth switch -account bob@x     # change the active account for an endpoint
+deploys <cmd> -account bob@x ...       # use a specific account for one command
+deploys auth token | some-tool         # print the resolved token for scripts
+```
+
+Accounts are keyed by `(endpoint, email)`, so the same email can hold separate
+sessions on prod, staging (`-endpoint`), and self-hosted servers. Each endpoint
+has its own active account.
+
+### Resolution order
+
+The CLI resolves credentials in this order (so CI is unaffected):
 
 1. **Service-account key (HTTP basic):** set both `DEPLOYS_AUTH_USER` and
    `DEPLOYS_AUTH_PASS`. The user is a service-account email
    (`<sid>@<project>.serviceaccount.deploys.app`) and the pass is its key secret.
    Best for CI.
 2. **Bearer token:** set `DEPLOYS_TOKEN` to an API token.
-3. **Application Default Credentials:** if neither of the above is set, the CLI
-   falls back to Google ADC (e.g. `gcloud auth application-default login`) and
-   uses the resulting access token.
+3. **Stored login:** the account selected by `-account` / `DEPLOYS_ACCOUNT`, else
+   the active account for the endpoint (from `deploys login`).
+4. **Application Default Credentials:** if none of the above apply, the CLI falls
+   back to Google ADC (e.g. `gcloud auth application-default login`).
 
-Point the CLI at a non-production API with `DEPLOYS_ENDPOINT`.
+A service-account key and `DEPLOYS_TOKEN` always win, so existing CI pipelines
+are untouched. Point the CLI at a non-production API with `DEPLOYS_ENDPOINT`, and
+at a non-production auth server with `DEPLOYS_AUTH_ENDPOINT`.
+
+> **Headless / SSH:** the loopback flow needs a browser on the same machine. On a
+> remote host, run `deploys login -no-browser` and forward the printed callback
+> port (`ssh -L <port>:127.0.0.1:<port> <host>`), or use the CI env vars above.
 
 ## Usage
 
@@ -120,6 +157,17 @@ deploys github link -project acme -repository acme/web \
 
 `deployment` (aliases `deploy`, `d`) and the short aliases `ps`, `wi`, `sa`, `eg`
 match the corresponding resource.
+
+### auth (and the top-level `login` / `logout`)
+
+- `login` `[-endpoint url] [-no-browser] [-port n] [-timeout 3m]` — browser sign-in; stores the account and makes it active. Same as `auth login`.
+- `logout` `[-account email] [-endpoint url] [-all] [-yes]` — revoke and remove an account (the active one by default). Same as `auth logout`.
+- `auth status` `[-endpoint url]` — show the credential in effect (env, stored login, or ADC fallback) and its expiry.
+- `auth list` — list stored accounts grouped by endpoint, marking the active one.
+- `auth switch` `-account email [-endpoint url]` — change the active account for an endpoint.
+- `auth token` `[-endpoint url] [-force]` — print the resolved bearer token (refuses a terminal without `-force`; prints with no trailing newline for `$(...)`).
+
+Use `-account email` (or `DEPLOYS_ACCOUNT`) on any command to pick a stored account for that invocation.
 
 ### me
 

--- a/internal/auth/login.go
+++ b/internal/auth/login.go
@@ -37,19 +37,29 @@ const loopbackHost = "127.0.0.1"
 // flow to another origin.
 const defaultAuthBase = "https://auth.deploys.app"
 
-// bakedInClientID returns a pre-provisioned public client_id for an auth base,
-// or "" to self-provision via Dynamic Client Registration. No client is seeded
-// today, so this is empty and the CLI registers (once, cached) against every
-// auth base. An operator may later seed a public client for the default host and
-// return it here to avoid per-machine DCR rows.
+// bakedInClientID returns the pre-provisioned public client_id for an auth base,
+// or "" to self-provision via Dynamic Client Registration. The production auth
+// server seeds a well-known "deploys-cli" public client (auth migration
+// 05_seed_cli_client.sql), so the common case never calls /register. Any other
+// auth base (forks, self-hosted, staging) falls back to DCR. If the seed is
+// absent the login self-heals: a stale baked-in id is detected and DCR takes
+// over (see Login).
 func bakedInClientID(authBase string) string {
+	if authBase == defaultAuthBase {
+		return "deploys-cli"
+	}
 	return ""
 }
 
 // errLoginTimeout is returned when the browser login does not complete in time.
-// It is also the signal that a stale cached client_id may be to blame (a bad id
-// is rejected at the authorize step in the browser, so the loopback never fires).
+// It is also a signal that a stale baked-in/cached client_id may be to blame (a
+// bad id is rejected at the authorize step in the browser, so the loopback never
+// fires and we only observe a timeout).
 var errLoginTimeout = errors.New("login timed out")
+
+// errInvalidClient is wrapped into a /token error when the server rejects the
+// client_id, so Login can fall back to a fresh DCR registration.
+var errInvalidClient = errors.New("invalid_client")
 
 // LoginOptions configures a browser login. Zero values are sensible defaults.
 type LoginOptions struct {
@@ -95,16 +105,19 @@ func Login(ctx context.Context, authBase, apiEndpoint string, opts LoginOptions)
 		return Result{}, err
 	}
 
-	clientID, fromCache, err := ensureClientID(ctx, authBase, meta.RegistrationEndpoint)
+	clientID, reusable, err := ensureClientID(ctx, authBase, meta.RegistrationEndpoint)
 	if err != nil {
 		return Result{}, err
 	}
 
 	res, err := runFlow(ctx, meta, clientID, opts)
-	if errors.Is(err, errLoginTimeout) && fromCache {
-		// A stale cached client_id is rejected in the browser at the authorize
-		// step, so the loopback never receives a callback and we only see a
-		// timeout. Re-register once and retry before giving up.
+	// A stale baked-in or cached client_id surfaces either as a /token
+	// invalid_client or — when the authorize step rejects it in the browser, so
+	// the loopback never fires — as a plain timeout. In either case, if the id was
+	// pre-existing (not freshly registered this run), re-register once via DCR,
+	// cache it, and retry before giving up. This self-heals an un-seeded or reset
+	// auth server.
+	if err != nil && reusable && (errors.Is(err, errLoginTimeout) || errors.Is(err, errInvalidClient)) && meta.RegistrationEndpoint != "" {
 		newID, rerr := registerClient(ctx, meta.RegistrationEndpoint)
 		if rerr == nil {
 			_ = SaveClientID(authBase, newID)
@@ -192,16 +205,26 @@ func sameOrigin(a, b string) bool {
 	return ua.Scheme == ub.Scheme && strings.EqualFold(ua.Host, ub.Host)
 }
 
-// ensureClientID returns a usable client_id: a baked-in one, the cached DCR id,
-// or a freshly registered one (cached for reuse). fromCache reports whether the
-// id came from the cache, so a timeout can trigger a single re-registration.
-func ensureClientID(ctx context.Context, authBase, regEndpoint string) (clientID string, fromCache bool, err error) {
-	if id := bakedInClientID(authBase); id != "" {
-		return id, false, nil
-	}
+// ensureClientID returns a usable client_id and whether it is "reusable" — i.e.
+// pre-existing (a cached DCR id or the baked-in id) rather than freshly
+// registered this run. Precedence is cache → baked-in → register:
+//
+//   - The cache is checked first so that once a DCR fallback has happened against
+//     an un-seeded base, later logins use that cached id instead of re-hitting
+//     the (still failing) baked-in id every time.
+//   - The baked-in id is next, so a seeded base (no cache entry) uses the shared
+//     well-known client and never calls /register.
+//   - Otherwise register once and cache it.
+//
+// reusable is true for the first two so Login can fall back to a fresh DCR if a
+// stale id is rejected; a freshly-registered id returns reusable=false (no loop).
+func ensureClientID(ctx context.Context, authBase, regEndpoint string) (clientID string, reusable bool, err error) {
 	if id, ok, lerr := LoadClientID(authBase); lerr != nil {
 		return "", false, lerr
 	} else if ok {
+		return id, true, nil
+	}
+	if id := bakedInClientID(authBase); id != "" {
 		return id, true, nil
 	}
 	if regEndpoint == "" {
@@ -425,7 +448,12 @@ func exchangeCode(ctx context.Context, tokenEndpoint, clientID, code, verifier, 
 		}
 		_ = json.Unmarshal(body, &oe)
 		if oe.Error != "" {
-			return Result{}, fmt.Errorf("token exchange failed: %s", strings.TrimSpace(oe.Error+" "+oe.Desc))
+			msg := fmt.Errorf("token exchange failed: %s", strings.TrimSpace(oe.Error+" "+oe.Desc))
+			if oe.Error == "invalid_client" {
+				// Wrap the sentinel so Login can fall back to a fresh DCR.
+				return Result{}, fmt.Errorf("%w: %w", errInvalidClient, msg)
+			}
+			return Result{}, msg
 		}
 		return Result{}, fmt.Errorf("token exchange failed: status %d", resp.StatusCode)
 	}

--- a/internal/auth/login.go
+++ b/internal/auth/login.go
@@ -1,0 +1,498 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os/exec"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+)
+
+// loopbackRedirect is the registered redirect URI. It is port-less: the auth
+// server's loopback rule matches any port for a 127.0.0.1 host, so a single
+// registration is reused across logins on arbitrary ephemeral ports. The runtime
+// redirect_uri carries the real port; both share this host and path.
+const loopbackRedirect = "http://127.0.0.1/callback"
+
+// loopbackHost is the only address the callback listener ever binds. 127.0.0.1
+// (never 0.0.0.0) keeps the callback off the LAN, and never "localhost" so the
+// registered and runtime hostnames match exactly and IPv4/IPv6 resolution is
+// unambiguous.
+const loopbackHost = "127.0.0.1"
+
+// defaultAuthBase is the production authorization server. Its issuer/origin is
+// the hard-pin: discovery may only confirm paths within it, never repoint the
+// flow to another origin.
+const defaultAuthBase = "https://auth.deploys.app"
+
+// bakedInClientID returns a pre-provisioned public client_id for an auth base,
+// or "" to self-provision via Dynamic Client Registration. No client is seeded
+// today, so this is empty and the CLI registers (once, cached) against every
+// auth base. An operator may later seed a public client for the default host and
+// return it here to avoid per-machine DCR rows.
+func bakedInClientID(authBase string) string {
+	return ""
+}
+
+// errLoginTimeout is returned when the browser login does not complete in time.
+// It is also the signal that a stale cached client_id may be to blame (a bad id
+// is rejected at the authorize step in the browser, so the loopback never fires).
+var errLoginTimeout = errors.New("login timed out")
+
+// LoginOptions configures a browser login. Zero values are sensible defaults.
+type LoginOptions struct {
+	// OpenBrowser opens the authorize URL. nil uses the platform opener. Tests
+	// inject a function that drives the flow against an httptest server.
+	OpenBrowser func(url string) error
+	// NoBrowser prints the URL instead of opening it.
+	NoBrowser bool
+	// Port pins the loopback port (for a fixed SSH forward). 0 = random.
+	Port int
+	// Timeout bounds the wait for the browser callback. 0 = 3 minutes.
+	Timeout time.Duration
+	// Stderr receives progress (the authorize URL, SSH guidance). nil discards.
+	Stderr io.Writer
+}
+
+// Result is a completed login: the bearer token and its lifetime.
+type Result struct {
+	Token     string
+	ExpiresIn time.Duration
+}
+
+type metadata struct {
+	Issuer                string `json:"issuer"`
+	AuthorizationEndpoint string `json:"authorization_endpoint"`
+	TokenEndpoint         string `json:"token_endpoint"`
+	RegistrationEndpoint  string `json:"registration_endpoint"`
+	RevocationEndpoint    string `json:"revocation_endpoint"`
+}
+
+// Login runs the full Authorization Code + PKCE + loopback browser flow against
+// authBase and returns the minted bearer. apiEndpoint is unused by the flow
+// itself (the caller resolves identity with it afterwards) but is accepted so the
+// signature reads end-to-end. On a timeout with a cached client_id, the client is
+// re-registered once and the flow retried (a stale id otherwise hangs silently).
+func Login(ctx context.Context, authBase, apiEndpoint string, opts LoginOptions) (Result, error) {
+	authBase = strings.TrimRight(authBase, "/")
+	if err := validateBase(authBase); err != nil {
+		return Result{}, err
+	}
+	meta, err := discoverMetadata(ctx, authBase)
+	if err != nil {
+		return Result{}, err
+	}
+
+	clientID, fromCache, err := ensureClientID(ctx, authBase, meta.RegistrationEndpoint)
+	if err != nil {
+		return Result{}, err
+	}
+
+	res, err := runFlow(ctx, meta, clientID, opts)
+	if errors.Is(err, errLoginTimeout) && fromCache {
+		// A stale cached client_id is rejected in the browser at the authorize
+		// step, so the loopback never receives a callback and we only see a
+		// timeout. Re-register once and retry before giving up.
+		newID, rerr := registerClient(ctx, meta.RegistrationEndpoint)
+		if rerr == nil {
+			_ = SaveClientID(authBase, newID)
+			res, err = runFlow(ctx, meta, newID, opts)
+		}
+	}
+	if err != nil {
+		return Result{}, err
+	}
+	return res, nil
+}
+
+// validateBase enforces https for any non-loopback auth/api base. A cleartext
+// non-loopback base would leak the 7-day bearer, so it is rejected outright.
+func validateBase(base string) error {
+	u, err := url.Parse(base)
+	if err != nil || u.Host == "" {
+		return fmt.Errorf("invalid endpoint %q", base)
+	}
+	switch u.Scheme {
+	case "https":
+		return nil
+	case "http":
+		if isLoopbackHostname(u.Hostname()) {
+			return nil
+		}
+	}
+	return fmt.Errorf("endpoint %q must use https", base)
+}
+
+func isLoopbackHostname(h string) bool {
+	return h == "127.0.0.1" || h == "::1" || h == "localhost"
+}
+
+// discoverMetadata fetches RFC 8414 metadata and pins it: the issuer must equal
+// the configured base and every endpoint must be same-origin as the issuer, so a
+// metadata doc can never repoint the token/registration endpoint at an
+// exfiltration host. Discovery only locates paths within the already-trusted
+// origin.
+func discoverMetadata(ctx context.Context, authBase string) (metadata, error) {
+	var m metadata
+	u := authBase + "/.well-known/oauth-authorization-server"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return m, err
+	}
+	resp, err := httpClient().Do(req)
+	if err != nil {
+		return m, fmt.Errorf("discover auth server: %w", err)
+	}
+	defer drain(resp)
+	if resp.StatusCode != http.StatusOK {
+		return m, fmt.Errorf("discover auth server: status %d", resp.StatusCode)
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&m); err != nil {
+		return m, fmt.Errorf("discover auth server: %w", err)
+	}
+
+	if strings.TrimRight(m.Issuer, "/") != authBase {
+		return m, fmt.Errorf("auth server issuer %q does not match %q", m.Issuer, authBase)
+	}
+	for _, ep := range []string{m.AuthorizationEndpoint, m.TokenEndpoint, m.RegistrationEndpoint, m.RevocationEndpoint} {
+		if ep == "" {
+			continue
+		}
+		if !sameOrigin(ep, m.Issuer) {
+			return m, fmt.Errorf("auth server endpoint %q is not same-origin as issuer %q", ep, m.Issuer)
+		}
+	}
+	if m.AuthorizationEndpoint == "" || m.TokenEndpoint == "" {
+		return m, errors.New("auth server metadata missing authorization or token endpoint")
+	}
+	return m, nil
+}
+
+func sameOrigin(a, b string) bool {
+	ua, err := url.Parse(a)
+	if err != nil {
+		return false
+	}
+	ub, err := url.Parse(b)
+	if err != nil {
+		return false
+	}
+	return ua.Scheme == ub.Scheme && strings.EqualFold(ua.Host, ub.Host)
+}
+
+// ensureClientID returns a usable client_id: a baked-in one, the cached DCR id,
+// or a freshly registered one (cached for reuse). fromCache reports whether the
+// id came from the cache, so a timeout can trigger a single re-registration.
+func ensureClientID(ctx context.Context, authBase, regEndpoint string) (clientID string, fromCache bool, err error) {
+	if id := bakedInClientID(authBase); id != "" {
+		return id, false, nil
+	}
+	if id, ok, lerr := LoadClientID(authBase); lerr != nil {
+		return "", false, lerr
+	} else if ok {
+		return id, true, nil
+	}
+	if regEndpoint == "" {
+		return "", false, errors.New("auth server does not advertise a registration endpoint")
+	}
+	id, rerr := registerClient(ctx, regEndpoint)
+	if rerr != nil {
+		return "", false, rerr
+	}
+	if serr := SaveClientID(authBase, id); serr != nil {
+		return "", false, serr
+	}
+	return id, false, nil
+}
+
+// registerClient performs Dynamic Client Registration (RFC 7591) for a public
+// client with the port-less loopback redirect.
+func registerClient(ctx context.Context, regEndpoint string) (string, error) {
+	body, _ := json.Marshal(map[string]any{
+		"client_name":                "deploys-cli",
+		"redirect_uris":              []string{loopbackRedirect},
+		"grant_types":                []string{"authorization_code"},
+		"response_types":             []string{"code"},
+		"token_endpoint_auth_method": "none",
+	})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, regEndpoint, strings.NewReader(string(body)))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := httpClient().Do(req)
+	if err != nil {
+		return "", fmt.Errorf("register client: %w", err)
+	}
+	defer drain(resp)
+	if resp.StatusCode/100 != 2 {
+		return "", fmt.Errorf("register client: status %d", resp.StatusCode)
+	}
+	var out struct {
+		ClientID string `json:"client_id"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&out); err != nil {
+		return "", fmt.Errorf("register client: %w", err)
+	}
+	if out.ClientID == "" {
+		return "", errors.New("register client: empty client_id in response")
+	}
+	return out.ClientID, nil
+}
+
+// runFlow starts the loopback listener, drives the browser, captures the code,
+// and exchanges it for a token.
+func runFlow(ctx context.Context, meta metadata, clientID string, opts LoginOptions) (Result, error) {
+	verifier, challenge := generatePKCE()
+	state := generateState()
+
+	addr := fmt.Sprintf("%s:%d", loopbackHost, opts.Port)
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		if opts.Port != 0 {
+			return Result{}, fmt.Errorf("port %d is in use; omit -port for a random port", opts.Port)
+		}
+		return Result{}, err
+	}
+	defer ln.Close()
+	port := ln.Addr().(*net.TCPAddr).Port
+	redirectURI := fmt.Sprintf("http://%s:%d/callback", loopbackHost, port)
+
+	authURL := buildAuthorizeURL(meta.AuthorizationEndpoint, clientID, state, redirectURI, challenge)
+
+	stderr := opts.Stderr
+	if stderr == nil {
+		stderr = io.Discard
+	}
+
+	code, err := captureCode(ctx, ln, state, opts, authURL, port, stderr)
+	if err != nil {
+		return Result{}, err
+	}
+
+	tok, err := exchangeCode(ctx, meta.TokenEndpoint, clientID, code, verifier, redirectURI)
+	if err != nil {
+		return Result{}, err
+	}
+	return tok, nil
+}
+
+// captureCode opens the browser, serves exactly one /callback on the loopback
+// listener, validates state, and returns the authorization code.
+func captureCode(ctx context.Context, ln net.Listener, state string, opts LoginOptions, authURL string, port int, stderr io.Writer) (string, error) {
+	done := make(chan struct {
+		code string
+		err  error
+	}, 1)
+	var once sync.Once
+	finish := func(code string, err error) {
+		once.Do(func() {
+			done <- struct {
+				code string
+				err  error
+			}{code, err}
+		})
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
+		setLoopbackHeaders(w)
+		q := r.URL.Query()
+		// Validate state first (constant-time): the callback is reachable by any
+		// local process, so a forged callback must be rejected.
+		if subtle.ConstantTimeCompare([]byte(q.Get("state")), []byte(state)) != 1 {
+			writeErrorPage(w)
+			finish("", errors.New("login failed: state mismatch"))
+			return
+		}
+		if e := q.Get("error"); e != "" {
+			writeErrorPage(w)
+			finish("", fmt.Errorf("authorization denied: %s", sanitizeOAuthError(e)))
+			return
+		}
+		code := q.Get("code")
+		if code == "" {
+			writeErrorPage(w)
+			finish("", errors.New("login failed: missing authorization code"))
+			return
+		}
+		writeSuccessPage(w)
+		finish(code, nil)
+	})
+	// Everything else 404s and never keeps the port alive or reflects input.
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})
+
+	srv := &http.Server{Handler: mux}
+	go srv.Serve(ln)
+	defer srv.Close()
+
+	openOrPrint(opts, authURL, port, stderr)
+
+	timeout := opts.Timeout
+	if timeout <= 0 {
+		timeout = 3 * time.Minute
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case res := <-done:
+		return res.code, res.err
+	case <-timer.C:
+		return "", errLoginTimeout
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+}
+
+// openOrPrint opens the browser (or prints the URL) and always echoes the
+// authorize URL so a headless box where the opener silently no-ops still gives
+// the user something to copy. With NoBrowser it also prints the SSH forward hint.
+func openOrPrint(opts LoginOptions, authURL string, port int, stderr io.Writer) {
+	open := opts.OpenBrowser
+	if open == nil {
+		open = defaultOpenBrowser
+	}
+	if !opts.NoBrowser {
+		fmt.Fprintln(stderr, "Opening your browser to sign in...")
+		if err := open(authURL); err != nil {
+			opts.NoBrowser = true
+		}
+	}
+	fmt.Fprintf(stderr, "If your browser did not open, visit:\n  %s\n", authURL)
+	if opts.NoBrowser {
+		fmt.Fprintf(stderr,
+			"\nOn a remote/SSH host, forward the callback port from your local machine:\n"+
+				"  ssh -L %d:127.0.0.1:%d <this-host>\n"+
+				"then open the URL above in your local browser.\n", port, port)
+	}
+}
+
+func buildAuthorizeURL(authzEndpoint, clientID, state, redirectURI, challenge string) string {
+	p := url.Values{}
+	p.Set("client_id", clientID)
+	p.Set("response_type", "code")
+	p.Set("state", state)
+	p.Set("redirect_uri", redirectURI)
+	p.Set("code_challenge", challenge)
+	p.Set("code_challenge_method", "S256")
+	sep := "?"
+	if strings.Contains(authzEndpoint, "?") {
+		sep = "&"
+	}
+	return authzEndpoint + sep + p.Encode()
+}
+
+// exchangeCode swaps the authorization code for a token at the token endpoint.
+func exchangeCode(ctx context.Context, tokenEndpoint, clientID, code, verifier, redirectURI string) (Result, error) {
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("client_id", clientID)
+	form.Set("code", code)
+	form.Set("code_verifier", verifier)
+	form.Set("redirect_uri", redirectURI)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenEndpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return Result{}, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := httpClient().Do(req)
+	if err != nil {
+		return Result{}, fmt.Errorf("token exchange: %w", err)
+	}
+	defer drain(resp)
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode != http.StatusOK {
+		var oe struct {
+			Error string `json:"error"`
+			Desc  string `json:"error_description"`
+		}
+		_ = json.Unmarshal(body, &oe)
+		if oe.Error != "" {
+			return Result{}, fmt.Errorf("token exchange failed: %s", strings.TrimSpace(oe.Error+" "+oe.Desc))
+		}
+		return Result{}, fmt.Errorf("token exchange failed: status %d", resp.StatusCode)
+	}
+
+	var out struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int    `json:"expires_in"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		return Result{}, fmt.Errorf("token exchange: %w", err)
+	}
+	if out.AccessToken == "" {
+		return Result{}, errors.New("token exchange: empty access_token")
+	}
+	exp := time.Duration(out.ExpiresIn) * time.Second
+	if exp <= 0 {
+		exp = 7 * 24 * time.Hour
+	}
+	return Result{Token: out.AccessToken, ExpiresIn: exp}, nil
+}
+
+func generatePKCE() (verifier, challenge string) {
+	b := make([]byte, 32)
+	_, _ = rand.Read(b)
+	verifier = base64.RawURLEncoding.EncodeToString(b)
+	sum := sha256.Sum256([]byte(verifier))
+	challenge = base64.RawURLEncoding.EncodeToString(sum[:])
+	return verifier, challenge
+}
+
+func generateState() string {
+	b := make([]byte, 16)
+	_, _ = rand.Read(b)
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+// sanitizeOAuthError whitelists a server-supplied OAuth error code to a short
+// known set so attacker-influenced callback content is never echoed verbatim.
+func sanitizeOAuthError(code string) string {
+	switch code {
+	case "access_denied", "invalid_request", "invalid_scope", "server_error",
+		"temporarily_unavailable", "unauthorized_client", "unsupported_response_type":
+		return code
+	default:
+		return "authorization error"
+	}
+}
+
+func defaultOpenBrowser(u string) error {
+	var name string
+	var args []string
+	switch runtime.GOOS {
+	case "darwin":
+		name, args = "open", []string{u}
+	case "windows":
+		name, args = "rundll32", []string{"url.dll,FileProtocolHandler", u}
+	default:
+		name, args = "xdg-open", []string{u}
+	}
+	return exec.Command(name, args...).Start()
+}
+
+func httpClient() *http.Client {
+	return &http.Client{Timeout: 20 * time.Second}
+}
+
+func drain(resp *http.Response) {
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+}

--- a/internal/auth/login_test.go
+++ b/internal/auth/login_test.go
@@ -1,0 +1,213 @@
+package auth
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeAuthServer is a minimal OAuth 2.1 + PKCE authorization server good enough
+// to drive the CLI flow end to end: discovery, DCR, authorize (which 302s to the
+// loopback redirect), and token (which verifies PKCE S256).
+func fakeAuthServer(t *testing.T) (*httptest.Server, *authProbe) {
+	t.Helper()
+	probe := &authProbe{challenges: map[string]string{}}
+	mux := http.NewServeMux()
+
+	var base string // set after the server starts
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                           base,
+			"authorization_endpoint":           base + "/authorize",
+			"token_endpoint":                   base + "/token",
+			"registration_endpoint":            base + "/register",
+			"revocation_endpoint":              base + "/revoke",
+			"code_challenge_methods_supported": []string{"S256"},
+			"grant_types_supported":            []string{"authorization_code"},
+		})
+	})
+	mux.HandleFunc("/register", func(w http.ResponseWriter, r *http.Request) {
+		probe.registered++
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{"client_id": "test-client"})
+	})
+	mux.HandleFunc("/authorize", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		probe.mu.Lock()
+		probe.method = q.Get("code_challenge_method")
+		probe.gotClientID = q.Get("client_id")
+		code := fmt.Sprintf("code-%d", probe.registered+1)
+		probe.challenges[code] = q.Get("code_challenge")
+		probe.mu.Unlock()
+		redirect := q.Get("redirect_uri")
+		http.Redirect(w, r, redirect+"?code="+code+"&state="+url.QueryEscape(q.Get("state")), http.StatusFound)
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		r.ParseForm()
+		code := r.Form.Get("code")
+		verifier := r.Form.Get("code_verifier")
+		probe.mu.Lock()
+		want := probe.challenges[code]
+		probe.mu.Unlock()
+		sum := sha256.Sum256([]byte(verifier))
+		if verifier == "" || base64.RawURLEncoding.EncodeToString(sum[:]) != want {
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(map[string]string{"error": "invalid_grant"})
+			return
+		}
+		probe.exchanged = true
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "deploys-api.test",
+			"token_type":   "Bearer",
+			"expires_in":   604800,
+		})
+	})
+
+	srv := httptest.NewServer(mux)
+	base = srv.URL
+	return srv, probe
+}
+
+type authProbe struct {
+	mu          sync.Mutex
+	challenges  map[string]string
+	method      string
+	gotClientID string
+	registered  int
+	exchanged   bool
+}
+
+func TestLogin(t *testing.T) {
+	t.Setenv("DEPLOYS_CONFIG_DIR", t.TempDir())
+	srv, probe := fakeAuthServer(t)
+	defer srv.Close()
+
+	// The injected "browser" just GETs the authorize URL; the default http client
+	// follows the 302 to the loopback /callback, delivering the code.
+	opener := func(rawURL string) error {
+		resp, err := http.Get(rawURL)
+		if resp != nil {
+			resp.Body.Close()
+		}
+		return err
+	}
+
+	res, err := Login(context.Background(), srv.URL, srv.URL, LoginOptions{
+		OpenBrowser: opener,
+		Timeout:     5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if res.Token != "deploys-api.test" {
+		t.Errorf("token = %q; want deploys-api.test", res.Token)
+	}
+	if res.ExpiresIn != 7*24*time.Hour {
+		t.Errorf("expiresIn = %v; want 7d", res.ExpiresIn)
+	}
+	if probe.method != "S256" {
+		t.Errorf("authorize code_challenge_method = %q; want S256", probe.method)
+	}
+	if !probe.exchanged {
+		t.Error("token endpoint did not verify/exchange the code")
+	}
+	// The client_id was registered once and cached.
+	if probe.registered != 1 {
+		t.Errorf("registered %d times; want 1", probe.registered)
+	}
+	if id, ok, _ := LoadClientID(srv.URL); !ok || id != "test-client" {
+		t.Errorf("client id not cached: id=%q ok=%v", id, ok)
+	}
+
+	// A second login reuses the cached client_id (no re-registration).
+	if _, err := Login(context.Background(), srv.URL, srv.URL, LoginOptions{OpenBrowser: opener, Timeout: 5 * time.Second}); err != nil {
+		t.Fatalf("second Login: %v", err)
+	}
+	if probe.registered != 1 {
+		t.Errorf("re-registered (count=%d); cached client_id should be reused", probe.registered)
+	}
+}
+
+func TestLoginStateMismatchFails(t *testing.T) {
+	t.Setenv("DEPLOYS_CONFIG_DIR", t.TempDir())
+	srv, _ := fakeAuthServer(t)
+	defer srv.Close()
+
+	// A malicious/garbled callback that carries the wrong state must be rejected.
+	opener := func(rawURL string) error {
+		u, _ := url.Parse(rawURL)
+		redirect := u.Query().Get("redirect_uri")
+		resp, err := http.Get(redirect + "?code=evil&state=wrong-state")
+		if resp != nil {
+			resp.Body.Close()
+		}
+		return err
+	}
+	_, err := Login(context.Background(), srv.URL, srv.URL, LoginOptions{OpenBrowser: opener, Timeout: 3 * time.Second})
+	if err == nil {
+		t.Fatal("expected login to fail on state mismatch")
+	}
+}
+
+func TestValidateBase(t *testing.T) {
+	ok := []string{"https://auth.deploys.app", "http://127.0.0.1:9000", "http://localhost:8080"}
+	bad := []string{"http://auth.deploys.app", "ftp://x", "://nope", "http://evil.example"}
+	for _, s := range ok {
+		if err := validateBase(s); err != nil {
+			t.Errorf("validateBase(%q) = %v; want ok", s, err)
+		}
+	}
+	for _, s := range bad {
+		if err := validateBase(s); err == nil {
+			t.Errorf("validateBase(%q) = nil; want error", s)
+		}
+	}
+}
+
+func TestDiscoverMetadataRejectsCrossOrigin(t *testing.T) {
+	// Endpoints that are not same-origin as the issuer must be rejected so a
+	// metadata doc cannot repoint the token endpoint at an exfiltration host.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                 "http://127.0.0.1:1", // wrong issuer
+			"authorization_endpoint": "https://evil.example/authorize",
+			"token_endpoint":         "https://evil.example/token",
+		})
+	}))
+	defer srv.Close()
+	if _, err := discoverMetadata(context.Background(), srv.URL); err == nil {
+		t.Error("expected discovery to reject mismatched issuer/cross-origin endpoints")
+	}
+}
+
+func TestRevoke(t *testing.T) {
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/revoke" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		var body struct {
+			Token string `json:"token"`
+		}
+		json.NewDecoder(r.Body).Decode(&body)
+		got = body.Token
+		json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	}))
+	defer srv.Close()
+
+	if err := Revoke(context.Background(), srv.URL, "deploys-api.tok"); err != nil {
+		t.Fatalf("Revoke: %v", err)
+	}
+	if got != "deploys-api.tok" {
+		t.Errorf("revoke received token %q; want deploys-api.tok", got)
+	}
+}

--- a/internal/auth/login_test.go
+++ b/internal/auth/login_test.go
@@ -52,6 +52,14 @@ func fakeAuthServer(t *testing.T) (*httptest.Server, *authProbe) {
 	})
 	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
 		r.ParseForm()
+		probe.mu.Lock()
+		reject := probe.rejectClientID
+		probe.mu.Unlock()
+		if reject != "" && r.Form.Get("client_id") == reject {
+			w.WriteHeader(http.StatusUnauthorized)
+			json.NewEncoder(w).Encode(map[string]string{"error": "invalid_client"})
+			return
+		}
 		code := r.Form.Get("code")
 		verifier := r.Form.Get("code_verifier")
 		probe.mu.Lock()
@@ -77,12 +85,13 @@ func fakeAuthServer(t *testing.T) (*httptest.Server, *authProbe) {
 }
 
 type authProbe struct {
-	mu          sync.Mutex
-	challenges  map[string]string
-	method      string
-	gotClientID string
-	registered  int
-	exchanged   bool
+	mu             sync.Mutex
+	challenges     map[string]string
+	method         string
+	gotClientID    string
+	registered     int
+	exchanged      bool
+	rejectClientID string // /token returns invalid_client for this client_id
 }
 
 func TestLogin(t *testing.T) {
@@ -133,6 +142,56 @@ func TestLogin(t *testing.T) {
 	}
 	if probe.registered != 1 {
 		t.Errorf("re-registered (count=%d); cached client_id should be reused", probe.registered)
+	}
+}
+
+func TestBakedInClientID(t *testing.T) {
+	if got := bakedInClientID("https://auth.deploys.app"); got != "deploys-cli" {
+		t.Errorf("baked-in for default = %q; want deploys-cli", got)
+	}
+	for _, b := range []string{"https://auth.staging", "http://127.0.0.1:9000", ""} {
+		if got := bakedInClientID(b); got != "" {
+			t.Errorf("baked-in for %q = %q; want empty (DCR)", b, got)
+		}
+	}
+}
+
+// A stale cached/baked-in client_id rejected at /token triggers a single DCR
+// re-registration and retry, so login self-heals against an un-seeded server.
+func TestLoginFallsBackToDCROnInvalidClient(t *testing.T) {
+	t.Setenv("DEPLOYS_CONFIG_DIR", t.TempDir())
+	srv, probe := fakeAuthServer(t)
+	defer srv.Close()
+
+	// Pre-cache a client_id the server will reject, so ensureClientID returns it
+	// as reusable and Login must fall back to DCR.
+	if err := SaveClientID(srv.URL, "stale-id"); err != nil {
+		t.Fatal(err)
+	}
+	probe.mu.Lock()
+	probe.rejectClientID = "stale-id"
+	probe.mu.Unlock()
+
+	opener := func(rawURL string) error {
+		resp, err := http.Get(rawURL)
+		if resp != nil {
+			resp.Body.Close()
+		}
+		return err
+	}
+	res, err := Login(context.Background(), srv.URL, srv.URL, LoginOptions{OpenBrowser: opener, Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("Login should self-heal via DCR: %v", err)
+	}
+	if res.Token != "deploys-api.test" {
+		t.Errorf("token = %q", res.Token)
+	}
+	if probe.registered != 1 {
+		t.Errorf("expected exactly one DCR fallback registration, got %d", probe.registered)
+	}
+	// The freshly registered id replaced the stale one in the cache.
+	if id, ok, _ := LoadClientID(srv.URL); !ok || id == "stale-id" {
+		t.Errorf("cache not updated after fallback: id=%q ok=%v", id, ok)
 	}
 }
 

--- a/internal/auth/logout.go
+++ b/internal/auth/logout.go
@@ -1,0 +1,39 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// Revoke best-effort revokes a token at the auth server's /revoke endpoint. The
+// endpoint is unauthenticated and returns ok unconditionally, so a 2xx confirms
+// only that the request reached a server — not that this specific token existed.
+// A network/non-2xx failure is returned so the caller can keep the local entry
+// rather than orphan a still-valid token.
+func Revoke(ctx context.Context, authBase, token string) error {
+	authBase = strings.TrimRight(authBase, "/")
+	if authBase == "" {
+		authBase = defaultAuthBase
+	}
+	if err := validateBase(authBase); err != nil {
+		return err
+	}
+	body, _ := json.Marshal(map[string]string{"token": token})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, authBase+"/revoke", strings.NewReader(string(body)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := httpClient().Do(req)
+	if err != nil {
+		return fmt.Errorf("revoke: %w", err)
+	}
+	defer drain(resp)
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("revoke: status %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/internal/auth/pages.go
+++ b/internal/auth/pages.go
@@ -1,0 +1,49 @@
+package auth
+
+import "net/http"
+
+// setLoopbackHeaders applies the safety headers shared by the success and error
+// pages: no referrer (so the code never leaks via a Referer header) and no
+// caching. Neither page reflects any request data, so there is no XSS surface in
+// the 127.0.0.1 origin that can read the code.
+func setLoopbackHeaders(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Referrer-Policy", "no-referrer")
+	w.Header().Set("Cache-Control", "no-store")
+}
+
+const successHTML = `<!doctype html>
+<html><head><meta charset="utf-8"><title>deploys.app</title></head>
+<body style="font-family:system-ui,sans-serif;text-align:center;margin-top:6rem">
+<h1>Login complete</h1>
+<p>You are signed in to the deploys.app CLI. You can close this tab.</p>
+</body></html>`
+
+const errorHTML = `<!doctype html>
+<html><head><meta charset="utf-8"><title>deploys.app</title></head>
+<body style="font-family:system-ui,sans-serif;text-align:center;margin-top:6rem">
+<h1>Login failed</h1>
+<p>Return to your terminal and run <code>deploys login</code> again.</p>
+</body></html>`
+
+func writeSuccessPage(w http.ResponseWriter) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(successHTML))
+	flush(w)
+}
+
+func writeErrorPage(w http.ResponseWriter) {
+	w.WriteHeader(http.StatusBadRequest)
+	_, _ = w.Write([]byte(errorHTML))
+	flush(w)
+}
+
+// flush pushes the buffered response onto the socket before the caller signals
+// completion. Without it, the listener can be closed (RFC 8252 §7.3: shut down
+// the instant the code arrives) before the response reaches the browser, which
+// then shows a connection reset instead of the page.
+func flush(w http.ResponseWriter) {
+	if f, ok := w.(http.Flusher); ok {
+		f.Flush()
+	}
+}

--- a/internal/auth/perm_unix.go
+++ b/internal/auth/perm_unix.go
@@ -1,0 +1,18 @@
+//go:build !windows
+
+package auth
+
+import (
+	"os"
+	"syscall"
+)
+
+// ownedByCurrentUser reports whether the file is owned by the current uid. If
+// the platform doesn't expose a uid (it always does on unix), it defers to true.
+func ownedByCurrentUser(fi os.FileInfo) (bool, error) {
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return true, nil
+	}
+	return int(st.Uid) == os.Getuid(), nil
+}

--- a/internal/auth/perm_windows.go
+++ b/internal/auth/perm_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package auth
+
+import "os"
+
+// ownedByCurrentUser is a no-op on Windows, where POSIX uid ownership does not
+// apply and os.Chmod only toggles the read-only bit. File ACLs are not enforced
+// here; this is documented as a best-effort limitation.
+func ownedByCurrentUser(os.FileInfo) (bool, error) {
+	return true, nil
+}

--- a/internal/auth/resolve.go
+++ b/internal/auth/resolve.go
@@ -1,0 +1,98 @@
+package auth
+
+import "fmt"
+
+// AuthRequiredError signals that the caller has no usable credential and must
+// log in (or that an explicitly-named account does not resolve). main maps it to
+// exit code 4 and prints its message verbatim. Its presence — not an HTTP status
+// — is how the CLI distinguishes "you need to log in" from other failures.
+type AuthRequiredError struct{ Msg string }
+
+func (e *AuthRequiredError) Error() string { return e.Msg }
+
+// Resolve picks the stored account for an endpoint, honoring selector precedence
+// (an explicit -account/DEPLOYS_ACCOUNT email, else the endpoint's active
+// account). explicit reports whether the selector was set explicitly, which
+// changes the failure mode:
+//
+//   - found and unexpired               -> (account, nil)
+//   - implicit and nothing usable       -> (nil, nil)            caller falls through to ADC
+//   - implicit active account expired   -> (account{expired}, nil) caller warns + falls through
+//   - explicit but missing or expired   -> (nil, *AuthRequiredError) caller hard-errors (exit 4)
+//
+// An expired account is reported via the returned expired flag; its token is
+// never returned (no refresh grant exists, so a dead token must not be sent).
+func Resolve(selector, endpoint string, explicit bool) (acct *Account, expired bool, err error) {
+	c, lerr := Load()
+	if lerr != nil {
+		return nil, false, lerr
+	}
+	ep := normalizeEndpoint(endpoint)
+
+	var key string
+	switch {
+	case selector != "":
+		key = AccountKey(ep, selector)
+	default:
+		if ak, ok := c.ActiveKey(ep); ok {
+			key = ak
+		}
+	}
+
+	if key == "" {
+		if explicit {
+			return nil, false, notFound(selector, ep)
+		}
+		return nil, false, nil
+	}
+
+	a, ok := c.Find(key)
+	if !ok {
+		if explicit {
+			return nil, false, notFound(selector, ep)
+		}
+		return nil, false, nil
+	}
+	if a.Expired() {
+		if explicit {
+			return nil, true, &AuthRequiredError{Msg: fmt.Sprintf(
+				"stored session for %s on %s has expired. Run 'deploys login' to sign in again.", a.Email, ep)}
+		}
+		return a, true, nil
+	}
+	return a, false, nil
+}
+
+// Lookup returns the selected/active account for an endpoint regardless of
+// expiry, for display by `deploys auth status`/`token`. A nil account with a nil
+// error means there is no stored account for the endpoint.
+func Lookup(selector, endpoint string) (*Account, error) {
+	c, err := Load()
+	if err != nil {
+		return nil, err
+	}
+	ep := normalizeEndpoint(endpoint)
+	var key string
+	if selector != "" {
+		key = AccountKey(ep, selector)
+	} else if ak, ok := c.ActiveKey(ep); ok {
+		key = ak
+	}
+	if key == "" {
+		return nil, nil
+	}
+	a, ok := c.Find(key)
+	if !ok {
+		return nil, nil
+	}
+	return a, nil
+}
+
+func notFound(selector, endpoint string) error {
+	if selector != "" {
+		return &AuthRequiredError{Msg: fmt.Sprintf(
+			"no stored login for %s on %s. Run 'deploys login' to sign in.", selector, endpoint)}
+	}
+	return &AuthRequiredError{Msg: fmt.Sprintf(
+		"no stored login for %s. Run 'deploys login' to sign in.", endpoint)}
+}

--- a/internal/auth/store.go
+++ b/internal/auth/store.go
@@ -1,0 +1,460 @@
+// Package auth implements the deploys CLI's interactive browser login and the
+// multi-account credential store that backs it.
+//
+// The store is a 0600 JSON file under the user's config dir. Accounts are keyed
+// by (api endpoint, email) so the same person can hold separate sessions per
+// endpoint (prod, staging, self-hosted) without collision, and a per-endpoint
+// "active" pointer selects the default account for each endpoint. A separate
+// 0600 file caches the dynamically-registered OAuth client_id per auth server.
+package auth
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// schemaVersion is the on-disk credentials schema version. A file written by a
+// newer CLI (higher version) is rejected rather than silently downgraded, so an
+// old binary never clobbers a format it does not understand.
+const schemaVersion = 1
+
+// keySep joins the normalized endpoint and the email into an account key. It is
+// a NUL byte: invisible in rendered JSON and impossible to occur inside a URL or
+// an email address, so the two halves can never be confused.
+const keySep = "\x00"
+
+// defaultEndpoint mirrors the api client's default base; normalizeEndpoint must
+// agree with client.Client.endpoint() so a stored key matches the endpoint the
+// client actually talks to.
+const defaultEndpoint = "https://api.deploys.app/"
+
+// Account is one stored login: the 7-day bearer token plus the identity and the
+// endpoints needed to use it and later revoke it.
+type Account struct {
+	Key          string    `json:"key"`          // normalizeEndpoint(endpoint) + keySep + email
+	Endpoint     string    `json:"endpoint"`     // normalized api base the token is used against
+	AuthEndpoint string    `json:"authEndpoint"` // auth base that minted the token (logout/revoke)
+	Email        string    `json:"email"`        // identity from me.get
+	Token        string    `json:"token"`        // "deploys-api." bearer (0600 protects it)
+	ExpiresAt    time.Time `json:"expiresAt"`    // issuedAt + expires_in (~7d)
+	IssuedAt     time.Time `json:"issuedAt"`
+}
+
+// Expired reports whether the token is at or past its expiry. A zero ExpiresAt
+// is treated as never-expiring (it should not happen for a real login).
+func (a Account) Expired() bool {
+	return !a.ExpiresAt.IsZero() && !time.Now().Before(a.ExpiresAt)
+}
+
+// Credentials is the whole on-disk account store.
+type Credentials struct {
+	Version  int               `json:"version"`
+	Active   map[string]string `json:"active,omitempty"` // normalized endpoint -> active account key
+	Accounts []Account         `json:"accounts"`
+}
+
+// AccountKey builds the storage key for an (endpoint, email) pair. The endpoint
+// is normalized so "https://api.deploys.app" and "https://api.deploys.app/"
+// collide to one key.
+func AccountKey(endpoint, email string) string {
+	return normalizeEndpoint(endpoint) + keySep + email
+}
+
+// normalizeEndpoint mirrors the api client's endpoint() normalization: an empty
+// value becomes the default base, and the result always ends in a single "/".
+func normalizeEndpoint(ep string) string {
+	if ep == "" {
+		return defaultEndpoint
+	}
+	return strings.TrimSuffix(ep, "/") + "/"
+}
+
+// NormalizeEndpoint is the exported form of normalizeEndpoint, for callers that
+// need the same normalized api base the store keys on.
+func NormalizeEndpoint(ep string) string { return normalizeEndpoint(ep) }
+
+// Find returns the account stored under key.
+func (c *Credentials) Find(key string) (*Account, bool) {
+	for i := range c.Accounts {
+		if c.Accounts[i].Key == key {
+			return &c.Accounts[i], true
+		}
+	}
+	return nil, false
+}
+
+// Upsert replaces the account with the same key, or appends it.
+func (c *Credentials) Upsert(a Account) {
+	for i := range c.Accounts {
+		if c.Accounts[i].Key == a.Key {
+			c.Accounts[i] = a
+			return
+		}
+	}
+	c.Accounts = append(c.Accounts, a)
+}
+
+// Remove deletes the account under key and clears any active pointer that
+// referenced it. If another account remains on the same endpoint, the active
+// pointer for that endpoint is repointed at it; otherwise the pointer is
+// dropped. It reports whether an account was removed.
+func (c *Credentials) Remove(key string) bool {
+	idx := -1
+	for i := range c.Accounts {
+		if c.Accounts[i].Key == key {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return false
+	}
+	endpoint := c.Accounts[idx].Endpoint
+	c.Accounts = append(c.Accounts[:idx], c.Accounts[idx+1:]...)
+
+	if c.Active[endpoint] == key {
+		delete(c.Active, endpoint)
+		// repoint to any remaining account on the same endpoint
+		for i := range c.Accounts {
+			if c.Accounts[i].Endpoint == endpoint {
+				if c.Active == nil {
+					c.Active = map[string]string{}
+				}
+				c.Active[endpoint] = c.Accounts[i].Key
+				break
+			}
+		}
+	}
+	return true
+}
+
+// SetActive points the given endpoint at the account key.
+func (c *Credentials) SetActive(endpoint, key string) {
+	if c.Active == nil {
+		c.Active = map[string]string{}
+	}
+	c.Active[normalizeEndpoint(endpoint)] = key
+}
+
+// ActiveKey returns the active account key for an endpoint.
+func (c *Credentials) ActiveKey(endpoint string) (string, bool) {
+	k, ok := c.Active[normalizeEndpoint(endpoint)]
+	return k, ok && k != ""
+}
+
+// ConfigDir resolves the directory holding the credential and client-id files,
+// in order: DEPLOYS_CONFIG_DIR, then XDG_CONFIG_HOME/deploys (honored even on
+// macOS, which os.UserConfigDir ignores), then os.UserConfigDir()/deploys.
+func ConfigDir() (string, error) {
+	if d := os.Getenv("DEPLOYS_CONFIG_DIR"); d != "" {
+		return d, nil
+	}
+	if x := os.Getenv("XDG_CONFIG_HOME"); x != "" {
+		return filepath.Join(x, "deploys"), nil
+	}
+	d, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(d, "deploys"), nil
+}
+
+func credentialsPath() (string, error) {
+	d, err := ConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(d, "credentials.json"), nil
+}
+
+func clientsPath() (string, error) {
+	d, err := ConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(d, "clients.json"), nil
+}
+
+// Load reads the credential store. A missing file yields an empty store (first
+// run). A malformed file or one written by a newer CLI is an error — never
+// silently treated as empty, which would discard every stored login.
+func Load() (*Credentials, error) {
+	path, err := credentialsPath()
+	if err != nil {
+		return nil, err
+	}
+	b, err := readFileSecure(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return &Credentials{Version: schemaVersion, Active: map[string]string{}}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var c Credentials
+	if err := json.Unmarshal(b, &c); err != nil {
+		return nil, fmt.Errorf("credentials file %s is corrupt: %w (inspect or remove it)", path, err)
+	}
+	if c.Version > schemaVersion {
+		return nil, fmt.Errorf("credentials file %s is version %d; upgrade the deploys cli", path, c.Version)
+	}
+	if c.Active == nil {
+		c.Active = map[string]string{}
+	}
+	return &c, nil
+}
+
+// Save writes the store atomically with 0600 permissions. Callers that
+// read-modify-write should use Mutate, which holds the store lock across the
+// whole cycle; Save itself does not lock.
+func (c *Credentials) Save() error {
+	c.Version = schemaVersion
+	path, err := credentialsPath()
+	if err != nil {
+		return err
+	}
+	if err := prepareDir(filepath.Dir(path)); err != nil {
+		return err
+	}
+	b, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return err
+	}
+	return writeFileAtomic(path, b)
+}
+
+// Mutate runs fn against the store under an exclusive lock, then saves. It is
+// the only safe way to change the store: a concurrent login/logout waits rather
+// than clobbering.
+func Mutate(fn func(*Credentials) error) error {
+	unlock, err := acquireLock("credentials.json.lock")
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	c, err := Load()
+	if err != nil {
+		return err
+	}
+	if err := fn(c); err != nil {
+		return err
+	}
+	return c.Save()
+}
+
+// clientCache is the on-disk DCR client_id cache, keyed by auth base URL.
+type clientCache struct {
+	Version int               `json:"version"`
+	Clients map[string]string `json:"clients"`
+}
+
+// LoadClientID returns the cached OAuth client_id for an auth base.
+func LoadClientID(authBase string) (string, bool, error) {
+	path, err := clientsPath()
+	if err != nil {
+		return "", false, err
+	}
+	b, err := readFileSecure(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	var cc clientCache
+	if err := json.Unmarshal(b, &cc); err != nil {
+		// A corrupt client cache is recoverable (we can re-register), so treat it
+		// as empty rather than failing the whole login.
+		return "", false, nil
+	}
+	id, ok := cc.Clients[authBase]
+	return id, ok && id != "", nil
+}
+
+// SaveClientID caches the OAuth client_id for an auth base.
+func SaveClientID(authBase, clientID string) error {
+	unlock, err := acquireLock("clients.json.lock")
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	path, err := clientsPath()
+	if err != nil {
+		return err
+	}
+	if err := prepareDir(filepath.Dir(path)); err != nil {
+		return err
+	}
+	var cc clientCache
+	if b, rerr := readFileSecure(path); rerr == nil {
+		_ = json.Unmarshal(b, &cc)
+	} else if !errors.Is(rerr, os.ErrNotExist) {
+		return rerr
+	}
+	if cc.Clients == nil {
+		cc.Clients = map[string]string{}
+	}
+	cc.Version = schemaVersion
+	cc.Clients[authBase] = clientID
+	b, err := json.MarshalIndent(&cc, "", "  ")
+	if err != nil {
+		return err
+	}
+	return writeFileAtomic(path, b)
+}
+
+// prepareDir creates the config dir 0700 and, on unix, refuses to proceed if it
+// is group/other-writable and cannot be tightened, or is owned by another user.
+// The whole at-rest model rests on a private parent dir.
+func prepareDir(dir string) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+	fi, err := os.Stat(dir)
+	if err != nil {
+		return err
+	}
+	if fi.Mode().Perm()&0o077 != 0 {
+		if err := os.Chmod(dir, 0o700); err != nil {
+			return fmt.Errorf("config dir %s is group/other-writable and could not be tightened: %w", dir, err)
+		}
+	}
+	owned, err := ownedByCurrentUser(fi)
+	if err != nil {
+		return err
+	}
+	if !owned {
+		return fmt.Errorf("refusing to use config dir %s: it is owned by another user", dir)
+	}
+	return nil
+}
+
+// writeFileAtomic writes data to path via a uniquely-named temp file in the same
+// dir (created O_EXCL with mode 0600, so a hostile pre-created symlink at a
+// predictable name cannot be clobbered and the mode is set at create time, not
+// by a later chmod), fsync'd, then renamed over the target. os.Rename replaces
+// atomically, so a reader never sees a torn file.
+func writeFileAtomic(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	tmp := filepath.Join(dir, "."+filepath.Base(path)+"."+randHex(8)+".tmp")
+	f, err := os.OpenFile(tmp, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	werr := func() error {
+		if _, err := f.Write(data); err != nil {
+			return err
+		}
+		return f.Sync()
+	}()
+	cerr := f.Close()
+	if werr != nil {
+		os.Remove(tmp)
+		return werr
+	}
+	if cerr != nil {
+		os.Remove(tmp)
+		return cerr
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+// readFileSecure reads a 0600 store file, refusing a symlink or a file owned by
+// another user, and tightening a loose-but-owned file. Permission/ownership
+// checks are unix-only (os.Chmod only toggles the read-only bit on Windows).
+func readFileSecure(path string) ([]byte, error) {
+	fi, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("refusing to read %s: it is a symlink", path)
+	}
+	if runtime.GOOS != "windows" {
+		owned, oerr := ownedByCurrentUser(fi)
+		if oerr != nil {
+			return nil, oerr
+		}
+		if !owned {
+			return nil, fmt.Errorf("refusing to read %s: it is owned by another user", path)
+		}
+		if fi.Mode().Perm()&0o077 != 0 {
+			if err := os.Chmod(path, 0o600); err != nil {
+				return nil, fmt.Errorf("%s is too permissive and could not be tightened: %w", path, err)
+			}
+		}
+	}
+	return os.ReadFile(path)
+}
+
+// acquireLock takes an exclusive O_EXCL lockfile (portable, unlike flock, which
+// Go cannot do cross-platform). A lockfile older than lockStale — or whose
+// recorded PID matches the current process from a crashed prior run — is broken
+// so an interrupted command can't wedge the store forever.
+func acquireLock(name string) (func(), error) {
+	dir, err := ConfigDir()
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, err
+	}
+	lockPath := filepath.Join(dir, name)
+	const lockStale = 30 * time.Second
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+		if err == nil {
+			fmt.Fprintf(f, "%d %d\n", os.Getpid(), time.Now().Unix())
+			f.Close()
+			return func() { os.Remove(lockPath) }, nil
+		}
+		if !os.IsExist(err) {
+			return nil, err
+		}
+		if lockIsStale(lockPath, lockStale) {
+			os.Remove(lockPath)
+			continue
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("the credential store is locked (%s); another deploys process may be running — remove the lock file if not", lockPath)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// lockIsStale reports whether a held lockfile is old enough to reclaim.
+func lockIsStale(lockPath string, maxAge time.Duration) bool {
+	fi, err := os.Stat(lockPath)
+	if err != nil {
+		// Vanished between OpenFile and Stat: treat as stale so the loop retries.
+		return true
+	}
+	return time.Since(fi.ModTime()) > maxAge
+}
+
+func randHex(n int) string {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		// crypto/rand failing is catastrophic and not something a CLI can paper
+		// over; fall back to a fixed marker so the O_EXCL create still guards us.
+		return "tmp"
+	}
+	return hex.EncodeToString(b)
+}

--- a/internal/auth/store_test.go
+++ b/internal/auth/store_test.go
@@ -1,0 +1,322 @@
+package auth
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestAccountKey(t *testing.T) {
+	// Endpoint normalization collides the trailing-slash and bare forms.
+	a := AccountKey("https://api.deploys.app", "alice@example.com")
+	b := AccountKey("https://api.deploys.app/", "alice@example.com")
+	if a != b {
+		t.Fatalf("keys differ across trailing slash: %q vs %q", a, b)
+	}
+	// Separator is a NUL byte, not a space.
+	if !strings.Contains(a, "\x00") {
+		t.Errorf("key missing NUL separator: %q", a)
+	}
+	// Empty endpoint resolves to the default.
+	if got := AccountKey("", "x@y"); !strings.HasPrefix(got, defaultEndpoint) {
+		t.Errorf("empty endpoint key = %q; want default-prefixed", got)
+	}
+}
+
+func TestNormalizeEndpoint(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"", defaultEndpoint},
+		{"https://api.deploys.app", "https://api.deploys.app/"},
+		{"https://api.deploys.app/", "https://api.deploys.app/"},
+		{"https://api.staging:8443", "https://api.staging:8443/"},
+	}
+	for _, c := range cases {
+		if got := normalizeEndpoint(c.in); got != c.want {
+			t.Errorf("normalizeEndpoint(%q) = %q; want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestGeneratePKCE(t *testing.T) {
+	v, c := generatePKCE()
+	if len(v) < 43 || len(v) > 128 {
+		t.Errorf("verifier length %d out of [43,128]", len(v))
+	}
+	sum := sha256.Sum256([]byte(v))
+	want := base64.RawURLEncoding.EncodeToString(sum[:])
+	if c != want {
+		t.Errorf("challenge = %q; want %q", c, want)
+	}
+	if strings.ContainsAny(v, "=+/") || strings.ContainsAny(c, "=+/") {
+		t.Errorf("PKCE values must be unpadded base64url: v=%q c=%q", v, c)
+	}
+}
+
+func TestStoreRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DEPLOYS_CONFIG_DIR", dir)
+
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("Load empty: %v", err)
+	}
+	if len(c.Accounts) != 0 {
+		t.Fatalf("fresh store should be empty, got %d", len(c.Accounts))
+	}
+
+	ep := "https://api.deploys.app/"
+	acc := Account{
+		Key:          AccountKey(ep, "alice@example.com"),
+		Endpoint:     ep,
+		AuthEndpoint: "https://auth.deploys.app",
+		Email:        "alice@example.com",
+		Token:        "deploys-api.abc",
+		ExpiresAt:    time.Now().Add(7 * 24 * time.Hour),
+		IssuedAt:     time.Now(),
+	}
+	if err := Mutate(func(cc *Credentials) error {
+		cc.Upsert(acc)
+		cc.SetActive(ep, acc.Key)
+		return nil
+	}); err != nil {
+		t.Fatalf("Mutate: %v", err)
+	}
+
+	// File mode is 0600 and no temp file is left behind.
+	path := filepath.Join(dir, "credentials.json")
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat credentials: %v", err)
+	}
+	if runtime.GOOS != "windows" && fi.Mode().Perm() != 0o600 {
+		t.Errorf("credentials mode = %v; want 0600", fi.Mode().Perm())
+	}
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("leftover temp file: %s", e.Name())
+		}
+	}
+
+	// Reload and assert content + active selection.
+	c2, err := Load()
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	got, ok := c2.Find(acc.Key)
+	if !ok || got.Token != "deploys-api.abc" {
+		t.Fatalf("account not round-tripped: %+v ok=%v", got, ok)
+	}
+	if k, ok := c2.ActiveKey(ep); !ok || k != acc.Key {
+		t.Errorf("active key = %q ok=%v; want %q", k, ok, acc.Key)
+	}
+
+	// Upsert replaces by key (no duplicate).
+	acc.Token = "deploys-api.def"
+	if err := Mutate(func(cc *Credentials) error { cc.Upsert(acc); return nil }); err != nil {
+		t.Fatalf("Mutate replace: %v", err)
+	}
+	c3, _ := Load()
+	if len(c3.Accounts) != 1 {
+		t.Errorf("expected 1 account after replace, got %d", len(c3.Accounts))
+	}
+	if a, _ := c3.Find(acc.Key); a.Token != "deploys-api.def" {
+		t.Errorf("replace did not update token: %q", a.Token)
+	}
+}
+
+func TestRemoveReassignsActive(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DEPLOYS_CONFIG_DIR", dir)
+
+	ep := "https://api.deploys.app/"
+	mk := func(email string) Account {
+		return Account{Key: AccountKey(ep, email), Endpoint: ep, Email: email, Token: "t-" + email, ExpiresAt: time.Now().Add(time.Hour)}
+	}
+	alice, bob := mk("alice@x"), mk("bob@x")
+	if err := Mutate(func(cc *Credentials) error {
+		cc.Upsert(alice)
+		cc.Upsert(bob)
+		cc.SetActive(ep, alice.Key)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Removing the active account repoints active to the remaining one.
+	if err := Mutate(func(cc *Credentials) error {
+		cc.Remove(alice.Key)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	c, _ := Load()
+	if k, ok := c.ActiveKey(ep); !ok || k != bob.Key {
+		t.Errorf("active after removing alice = %q ok=%v; want bob", k, ok)
+	}
+}
+
+func TestLoadCorruptAndVersion(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DEPLOYS_CONFIG_DIR", dir)
+	path := filepath.Join(dir, "credentials.json")
+
+	// Missing file -> empty, not error.
+	if _, err := Load(); err != nil {
+		t.Fatalf("missing file should be empty creds, got %v", err)
+	}
+
+	// Malformed -> error (never silently empty).
+	if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(); err == nil {
+		t.Error("malformed file should error")
+	}
+
+	// Higher version -> error.
+	if err := os.WriteFile(path, []byte(`{"version":999,"accounts":[]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load()
+	if err == nil || !strings.Contains(err.Error(), "version") {
+		t.Errorf("higher version should error mentioning version, got %v", err)
+	}
+}
+
+func TestClientIDCache(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DEPLOYS_CONFIG_DIR", dir)
+
+	if _, ok, err := LoadClientID("https://auth.deploys.app"); err != nil || ok {
+		t.Fatalf("empty cache: ok=%v err=%v", ok, err)
+	}
+	if err := SaveClientID("https://auth.deploys.app", "cid-123"); err != nil {
+		t.Fatalf("SaveClientID: %v", err)
+	}
+	id, ok, err := LoadClientID("https://auth.deploys.app")
+	if err != nil || !ok || id != "cid-123" {
+		t.Fatalf("LoadClientID = %q ok=%v err=%v", id, ok, err)
+	}
+	// A different auth base is independent.
+	if _, ok, _ := LoadClientID("https://auth.other"); ok {
+		t.Error("client id should be keyed per auth base")
+	}
+}
+
+func TestMutateTightensLoosePerms(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("posix perms not enforced on windows")
+	}
+	dir := t.TempDir()
+	t.Setenv("DEPLOYS_CONFIG_DIR", dir)
+	path := filepath.Join(dir, "credentials.json")
+	if err := os.WriteFile(path, []byte(`{"version":1,"accounts":[]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A read should tighten the loose-but-owned file to 0600.
+	if _, err := Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	fi, _ := os.Stat(path)
+	if fi.Mode().Perm()&0o077 != 0 {
+		t.Errorf("perms not tightened: %v", fi.Mode().Perm())
+	}
+}
+
+func TestLoadRefusesSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on windows")
+	}
+	dir := t.TempDir()
+	t.Setenv("DEPLOYS_CONFIG_DIR", dir)
+	target := filepath.Join(dir, "real.json")
+	if err := os.WriteFile(target, []byte(`{"version":1,"accounts":[]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "credentials.json")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load()
+	if err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Errorf("expected symlink refusal, got %v", err)
+	}
+}
+
+func TestExpired(t *testing.T) {
+	if (Account{ExpiresAt: time.Now().Add(time.Hour)}).Expired() {
+		t.Error("future expiry should not be expired")
+	}
+	if !(Account{ExpiresAt: time.Now().Add(-time.Hour)}).Expired() {
+		t.Error("past expiry should be expired")
+	}
+	if (Account{}).Expired() {
+		t.Error("zero expiry should be treated as non-expiring")
+	}
+}
+
+func TestResolveExplicitVsImplicit(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DEPLOYS_CONFIG_DIR", dir)
+
+	ep := "https://api.deploys.app/"
+	staging := "https://api.staging:8443/"
+	now := time.Now()
+	if err := Mutate(func(cc *Credentials) error {
+		cc.Upsert(Account{Key: AccountKey(ep, "alice@x"), Endpoint: ep, Email: "alice@x", Token: "tok-alice", ExpiresAt: now.Add(time.Hour)})
+		cc.Upsert(Account{Key: AccountKey(ep, "bob@x"), Endpoint: ep, Email: "bob@x", Token: "tok-bob", ExpiresAt: now.Add(time.Hour)})
+		cc.Upsert(Account{Key: AccountKey(ep, "old@x"), Endpoint: ep, Email: "old@x", Token: "tok-old", ExpiresAt: now.Add(-time.Hour)})
+		cc.Upsert(Account{Key: AccountKey(staging, "alice@x"), Endpoint: staging, Email: "alice@x", Token: "tok-staging", ExpiresAt: now.Add(time.Hour)})
+		cc.SetActive(ep, AccountKey(ep, "alice@x"))
+		cc.SetActive(staging, AccountKey(staging, "alice@x"))
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Active default on prod.
+	if a, expired, err := Resolve("", ep, false); err != nil || expired || a == nil || a.Token != "tok-alice" {
+		t.Errorf("active prod = %+v expired=%v err=%v", a, expired, err)
+	}
+	// Per-endpoint active map keeps staging independent.
+	if a, _, err := Resolve("", staging, false); err != nil || a == nil || a.Token != "tok-staging" {
+		t.Errorf("active staging = %+v err=%v", a, err)
+	}
+	// Explicit selector picks a non-active account.
+	if a, _, err := Resolve("bob@x", ep, true); err != nil || a == nil || a.Token != "tok-bob" {
+		t.Errorf("explicit bob = %+v err=%v", a, err)
+	}
+	// Implicit miss (selector for nonexistent, but implicit) -> nothing, no error.
+	if a, expired, err := Resolve("ghost@x", "https://api.unknown/", false); err != nil || a != nil || expired {
+		t.Errorf("implicit miss should be (nil,false,nil); got %+v %v %v", a, expired, err)
+	}
+	// Explicit miss -> hard AuthRequiredError.
+	_, _, err := Resolve("ghost@x", ep, true)
+	var are *AuthRequiredError
+	if !errors.As(err, &are) {
+		t.Errorf("explicit miss should be AuthRequiredError, got %v", err)
+	}
+	// Implicit expired active -> account returned with expired=true, no token use.
+	if err := Mutate(func(cc *Credentials) error {
+		cc.SetActive(ep, AccountKey(ep, "old@x"))
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	a, expired, err := Resolve("", ep, false)
+	if err != nil || !expired || a == nil {
+		t.Errorf("implicit expired = %+v expired=%v err=%v; want expired account", a, expired, err)
+	}
+	// Explicit expired -> hard error.
+	_, _, err = Resolve("old@x", ep, true)
+	if !errors.As(err, &are) {
+		t.Errorf("explicit expired should be AuthRequiredError, got %v", err)
+	}
+}

--- a/internal/runner/auth.go
+++ b/internal/runner/auth.go
@@ -1,0 +1,576 @@
+package runner
+
+import (
+	"bufio"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/deploys-app/api"
+	"github.com/deploys-app/api/client"
+
+	"github.com/deploys-app/deploys/internal/auth"
+)
+
+// doLogin is the login entry point, indirected so tests can stub the browser
+// flow and assert the runner's persistence/identity wiring without a network.
+var doLogin = auth.Login
+
+// authBaseURL resolves the authorization server base: DEPLOYS_AUTH_ENDPOINT, or
+// the production default. It is independent of the api endpoint.
+func authBaseURL() string {
+	if b := os.Getenv("DEPLOYS_AUTH_ENDPOINT"); b != "" {
+		return b
+	}
+	return "https://auth.deploys.app"
+}
+
+// apiEndpointFor resolves the api endpoint for an auth command: the -endpoint
+// flag, else DEPLOYS_ENDPOINT.
+func apiEndpointFor(flagVal string) string {
+	if flagVal != "" {
+		return flagVal
+	}
+	return os.Getenv("DEPLOYS_ENDPOINT")
+}
+
+// selector returns the account selector: the global -account (pre-scanned in
+// main), else DEPLOYS_ACCOUNT.
+func (rn Runner) selector() string {
+	if rn.Account != "" {
+		return rn.Account
+	}
+	return os.Getenv("DEPLOYS_ACCOUNT")
+}
+
+func (rn Runner) login(args ...string) error {
+	if len(args) > 0 && IsHelpArg(args[0]) {
+		writeLoginUsage(rn.output())
+		return nil
+	}
+	f := flag.NewFlagSet("deploys login", flag.ExitOnError)
+	f.SetOutput(rn.output())
+	f.Usage = func() { writeLoginUsage(rn.output()) }
+	var (
+		endpoint  string
+		noBrowser bool
+		port      int
+		timeout   time.Duration
+	)
+	f.StringVar(&endpoint, "endpoint", "", "api endpoint for this account (default $DEPLOYS_ENDPOINT or https://api.deploys.app/)")
+	f.BoolVar(&noBrowser, "no-browser", false, "print the authorization URL instead of opening a browser")
+	f.IntVar(&port, "port", 0, "loopback callback port for a fixed SSH forward (default: a random free port)")
+	f.DurationVar(&timeout, "timeout", 3*time.Minute, "how long to wait for the browser login")
+	if err := f.Parse(args); err != nil {
+		return err
+	}
+
+	apiEndpoint := apiEndpointFor(endpoint)
+	authBase := authBaseURL()
+
+	res, err := doLogin(context.Background(), authBase, apiEndpoint, auth.LoginOptions{
+		NoBrowser: noBrowser,
+		Port:      port,
+		Timeout:   timeout,
+		Stderr:    os.Stderr,
+	})
+	if err != nil {
+		return err
+	}
+
+	now := time.Now()
+	email, resolved := meGetEmail(apiEndpoint, res.Token)
+	if !resolved {
+		email = placeholderEmail(res.Token)
+	}
+
+	acct := auth.Account{
+		Key:          auth.AccountKey(apiEndpoint, email),
+		Endpoint:     auth.NormalizeEndpoint(apiEndpoint),
+		AuthEndpoint: authBase,
+		Email:        email,
+		Token:        res.Token,
+		ExpiresAt:    now.Add(res.ExpiresIn),
+		IssuedAt:     now,
+	}
+	if err := auth.Mutate(func(c *auth.Credentials) error {
+		c.Upsert(acct)
+		c.SetActive(apiEndpoint, acct.Key)
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	if resolved {
+		fmt.Fprintf(rn.output(), "Logged in as %s (now active)\n", email)
+	} else {
+		fmt.Fprintln(os.Stderr, "warning: logged in, but could not resolve your email (me.get failed); "+
+			"stored under the token only — run 'deploys auth status' once online to backfill identity")
+		fmt.Fprintln(rn.output(), "Logged in (identity unresolved; now active)")
+	}
+	return nil
+}
+
+// meGetEmail resolves the authenticated identity for a freshly minted token. It
+// builds its own one-off client (rn.API is nil for auth commands) with the same
+// 15s timeout newAPIClient uses, so a hung me.get can't strand the token.
+func meGetEmail(endpoint, token string) (string, bool) {
+	c := &client.Client{
+		Endpoint:   endpoint,
+		Channel:    api.AuditChannelCLI,
+		HTTPClient: &http.Client{Timeout: 15 * time.Second},
+		Auth: func(r *http.Request) {
+			r.Header.Set("Authorization", "Bearer "+token)
+		},
+	}
+	res, err := c.Me().Get(context.Background(), &api.Empty{})
+	if err != nil || res == nil || res.Email == "" {
+		return "", false
+	}
+	return res.Email, true
+}
+
+// placeholderEmail derives a stable, addressable identity for an account whose
+// me.get failed, so the entry is still revocable by key.
+func placeholderEmail(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return "unresolved-" + hex.EncodeToString(sum[:4]) + "@local"
+}
+
+func (rn Runner) logout(args ...string) error {
+	if len(args) > 0 && IsHelpArg(args[0]) {
+		writeLogoutUsage(rn.output())
+		return nil
+	}
+	f := flag.NewFlagSet("deploys logout", flag.ExitOnError)
+	f.SetOutput(rn.output())
+	f.Usage = func() { writeLogoutUsage(rn.output()) }
+	var (
+		endpoint string
+		all      bool
+		yes      bool
+	)
+	f.StringVar(&endpoint, "endpoint", "", "api endpoint of the account to log out (default $DEPLOYS_ENDPOINT)")
+	f.BoolVar(&all, "all", false, "remove every stored account")
+	f.BoolVar(&yes, "yes", false, "skip the confirmation prompt (required for -all without a terminal)")
+	if err := f.Parse(args); err != nil {
+		return err
+	}
+
+	if all {
+		return rn.logoutAll(yes)
+	}
+
+	apiEndpoint := apiEndpointFor(endpoint)
+	acct, err := auth.Lookup(rn.selector(), apiEndpoint)
+	if err != nil {
+		return err
+	}
+	if acct == nil {
+		fmt.Fprintln(rn.output(), "nothing to log out")
+		return nil
+	}
+
+	// Best-effort server-side revoke against the auth base that minted the token.
+	// On failure, keep the entry and fail loudly — never orphan a live token.
+	if rerr := auth.Revoke(context.Background(), acct.AuthEndpoint, acct.Token); rerr != nil {
+		return fmt.Errorf("token NOT revoked server-side (%v); it remains valid until %s. "+
+			"Re-run 'deploys logout' when online", rerr, acct.ExpiresAt.Format(time.RFC3339))
+	}
+
+	norm := auth.NormalizeEndpoint(apiEndpoint)
+	var reassigned string
+	if err := auth.Mutate(func(c *auth.Credentials) error {
+		c.Remove(acct.Key)
+		if k, ok := c.ActiveKey(norm); ok {
+			if a, ok := c.Find(k); ok {
+				reassigned = a.Email
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(rn.output(), "Logged out %s (removed; revoke acknowledged by %s)\n", acct.Email, acct.AuthEndpoint)
+	if reassigned != "" {
+		fmt.Fprintf(rn.output(), "Active account for %s is now %s\n", norm, reassigned)
+	}
+	return nil
+}
+
+func (rn Runner) logoutAll(yes bool) error {
+	c, err := auth.Load()
+	if err != nil {
+		return err
+	}
+	if len(c.Accounts) == 0 {
+		fmt.Fprintln(rn.output(), "nothing to log out")
+		return nil
+	}
+	if !yes {
+		if !isTTY(os.Stdin) {
+			return fmt.Errorf("refusing to remove all accounts without -yes (no interactive terminal)")
+		}
+		fmt.Fprintf(rn.output(), "Remove all %d stored account(s)? [y/N]: ", len(c.Accounts))
+		if !readYes(os.Stdin) {
+			fmt.Fprintln(rn.output(), "aborted")
+			return nil
+		}
+	}
+
+	var revokedKeys []string
+	var failed []string
+	for _, a := range c.Accounts {
+		if rerr := auth.Revoke(context.Background(), a.AuthEndpoint, a.Token); rerr != nil {
+			failed = append(failed, a.Email)
+			continue
+		}
+		revokedKeys = append(revokedKeys, a.Key)
+	}
+	if err := auth.Mutate(func(cc *auth.Credentials) error {
+		for _, k := range revokedKeys {
+			cc.Remove(k)
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(rn.output(), "Removed %d account(s)\n", len(revokedKeys))
+	if len(failed) > 0 {
+		return fmt.Errorf("could not revoke %d account(s) (kept locally): %s — re-run when online",
+			len(failed), strings.Join(failed, ", "))
+	}
+	return nil
+}
+
+func (rn Runner) authGroup(args ...string) error {
+	if len(args) == 0 || IsHelpArg(args[0]) {
+		return rn.groupUsage("auth")
+	}
+	switch args[0] {
+	default:
+		return rn.unknownSub("auth", args[0])
+	case "login":
+		return rn.login(args[1:]...)
+	case "logout":
+		return rn.logout(args[1:]...)
+	case "status":
+		return rn.authStatus(args[1:]...)
+	case "list":
+		return rn.authList(args[1:]...)
+	case "switch":
+		return rn.authSwitch(args[1:]...)
+	case "token":
+		return rn.authToken(args[1:]...)
+	}
+}
+
+// authStatusItem is the structured form of `deploys auth status` for -ojson/yaml.
+// It carries only the in-effect credential's facts (no KYC, no token).
+type authStatusItem struct {
+	Source    string     `json:"source" yaml:"source"`
+	Endpoint  string     `json:"endpoint" yaml:"endpoint"`
+	Account   string     `json:"account" yaml:"account"`
+	ExpiresAt *time.Time `json:"expiresAt,omitempty" yaml:"expiresAt,omitempty"`
+}
+
+func (rn Runner) authStatus(args ...string) error {
+	f := rn.subFlagSet("auth", "status")
+	var endpoint string
+	f.StringVar(&endpoint, "endpoint", "", "api endpoint to report (default $DEPLOYS_ENDPOINT)")
+	if err := f.Parse(args); err != nil {
+		return err
+	}
+	apiEndpoint := apiEndpointFor(endpoint)
+	norm := auth.NormalizeEndpoint(apiEndpoint)
+
+	var item authStatusItem
+	item.Endpoint = norm
+	expiresLine := "(n/a)"
+
+	switch {
+	case os.Getenv("DEPLOYS_AUTH_USER") != "" && os.Getenv("DEPLOYS_AUTH_PASS") != "":
+		item.Source = "DEPLOYS_AUTH_USER/DEPLOYS_AUTH_PASS environment (service account)"
+		item.Account = os.Getenv("DEPLOYS_AUTH_USER")
+		expiresLine = "(unknown — managed by the environment)"
+	case os.Getenv("DEPLOYS_TOKEN") != "":
+		item.Source = "DEPLOYS_TOKEN environment variable"
+		item.Account = "(unknown — env token carries no identity)"
+		expiresLine = "(unknown — managed by the environment)"
+	default:
+		acct, err := auth.Lookup(rn.selector(), apiEndpoint)
+		if err != nil {
+			return err
+		}
+		if acct == nil {
+			// No env credential and no stored account; a normal command may still
+			// authenticate via Google ADC (the legacy fallback), which status does
+			// not probe — so phrase this honestly rather than "not logged in".
+			item.Source = "no stored login (commands fall back to env vars or Google ADC)"
+			item.Account = "(none — run 'deploys login')"
+		} else {
+			item.Source = "active account (credentials file)"
+			item.Account = acct.Email
+			e := acct.ExpiresAt
+			item.ExpiresAt = &e
+			expiresLine = formatExpiry(e)
+		}
+	}
+
+	if rn.OutputMode == "" || rn.OutputMode == "table" {
+		out := rn.output()
+		fmt.Fprintf(out, "%-10s%s\n", "Source", item.Source)
+		fmt.Fprintf(out, "%-10s%s\n", "Endpoint", item.Endpoint)
+		fmt.Fprintf(out, "%-10s%s\n", "Account", item.Account)
+		fmt.Fprintf(out, "%-10s%s\n", "Expires", expiresLine)
+		if item.ExpiresAt != nil {
+			if d := time.Until(*item.ExpiresAt); d > 0 && d < 24*time.Hour {
+				fmt.Fprintf(os.Stderr, "warning: your deploys session expires in %s — run 'deploys login' to sign in again\n", humanDur(d))
+			}
+		}
+		return nil
+	}
+	return rn.print(item)
+}
+
+// AuthListItem is one row of `deploys auth list`.
+type AuthListItem struct {
+	Active   bool   `json:"active" yaml:"active"`
+	Endpoint string `json:"endpoint" yaml:"endpoint"`
+	Account  string `json:"account" yaml:"account"`
+	Expires  string `json:"expires" yaml:"expires"`
+}
+
+type authListResult struct {
+	Items []AuthListItem `json:"items" yaml:"items"`
+}
+
+func (a authListResult) Table() [][]string {
+	rows := [][]string{{"ACTIVE", "ENDPOINT", "ACCOUNT", "EXPIRES"}}
+	for _, it := range a.Items {
+		active := ""
+		if it.Active {
+			active = "*"
+		}
+		rows = append(rows, []string{active, it.Endpoint, it.Account, it.Expires})
+	}
+	return rows
+}
+
+func (rn Runner) authList(args ...string) error {
+	f := rn.subFlagSet("auth", "list")
+	if err := f.Parse(args); err != nil {
+		return err
+	}
+	c, err := auth.Load()
+	if err != nil {
+		return err
+	}
+	if len(c.Accounts) == 0 {
+		fmt.Fprintln(rn.output(), "no stored accounts (run 'deploys login')")
+		return nil
+	}
+
+	accts := append([]auth.Account(nil), c.Accounts...)
+	sort.Slice(accts, func(i, j int) bool {
+		if accts[i].Endpoint != accts[j].Endpoint {
+			return accts[i].Endpoint < accts[j].Endpoint
+		}
+		return accts[i].Email < accts[j].Email
+	})
+
+	var items []AuthListItem
+	for _, a := range accts {
+		active := false
+		if k, ok := c.ActiveKey(a.Endpoint); ok && k == a.Key {
+			active = true
+		}
+		items = append(items, AuthListItem{
+			Active:   active,
+			Endpoint: a.Endpoint,
+			Account:  a.Email,
+			Expires:  formatExpiryShort(a.ExpiresAt),
+		})
+	}
+	return rn.print(authListResult{Items: items})
+}
+
+func (rn Runner) authSwitch(args ...string) error {
+	f := rn.subFlagSet("auth", "switch")
+	var endpoint string
+	f.StringVar(&endpoint, "endpoint", "", "api endpoint whose active account to change (default $DEPLOYS_ENDPOINT)")
+	if err := f.Parse(args); err != nil {
+		return err
+	}
+	apiEndpoint := apiEndpointFor(endpoint)
+	norm := auth.NormalizeEndpoint(apiEndpoint)
+	sel := rn.selector()
+
+	c, err := auth.Load()
+	if err != nil {
+		return err
+	}
+	var onEp []auth.Account
+	for _, a := range c.Accounts {
+		if a.Endpoint == norm {
+			onEp = append(onEp, a)
+		}
+	}
+	if len(onEp) == 0 {
+		return &auth.AuthRequiredError{Msg: fmt.Sprintf("no stored accounts for %s; run 'deploys login'", norm)}
+	}
+
+	var target *auth.Account
+	if sel != "" {
+		key := auth.AccountKey(apiEndpoint, sel)
+		for i := range onEp {
+			if onEp[i].Key == key {
+				target = &onEp[i]
+				break
+			}
+		}
+		if target == nil {
+			return &auth.AuthRequiredError{Msg: fmt.Sprintf("no stored login for %s on %s", sel, norm)}
+		}
+	} else if len(onEp) == 1 {
+		target = &onEp[0]
+	} else {
+		var names []string
+		for _, a := range onEp {
+			names = append(names, a.Email)
+		}
+		return fmt.Errorf("multiple accounts on %s (%s); pass -account <email>", norm, strings.Join(names, ", "))
+	}
+
+	if err := auth.Mutate(func(cc *auth.Credentials) error {
+		cc.SetActive(apiEndpoint, target.Key)
+		return nil
+	}); err != nil {
+		return err
+	}
+	fmt.Fprintf(rn.output(), "Active account for %s is now %s\n", norm, target.Email)
+	return nil
+}
+
+func (rn Runner) authToken(args ...string) error {
+	f := rn.subFlagSet("auth", "token")
+	var (
+		endpoint string
+		force    bool
+	)
+	f.StringVar(&endpoint, "endpoint", "", "api endpoint of the account (default $DEPLOYS_ENDPOINT)")
+	f.BoolVar(&force, "force", false, "print even when stdout is a terminal")
+	if err := f.Parse(args); err != nil {
+		return err
+	}
+	apiEndpoint := apiEndpointFor(endpoint)
+
+	// Mirror a normal command's credential precedence.
+	if os.Getenv("DEPLOYS_AUTH_USER") != "" && os.Getenv("DEPLOYS_AUTH_PASS") != "" {
+		return fmt.Errorf("active credential is a service-account key, not a bearer token")
+	}
+	var token string
+	if t := os.Getenv("DEPLOYS_TOKEN"); t != "" {
+		token = t
+	} else {
+		acct, err := auth.Lookup(rn.selector(), apiEndpoint)
+		if err != nil {
+			return err
+		}
+		if acct == nil {
+			return &auth.AuthRequiredError{Msg: "not logged in. Run 'deploys login' to sign in."}
+		}
+		if acct.Expired() {
+			return &auth.AuthRequiredError{Msg: "your deploys session has expired. Run 'deploys login' to sign in again."}
+		}
+		token = acct.Token
+	}
+
+	out := rn.output()
+	tty := isTTY(out)
+	if tty && !force {
+		return fmt.Errorf("refusing to print a token to a terminal; pipe it, or pass -force")
+	}
+	if tty {
+		fmt.Fprintln(out, token)
+	} else {
+		// No trailing newline so $(deploys auth token) captures the exact value.
+		fmt.Fprint(out, token)
+	}
+	return nil
+}
+
+func isTTY(f *os.File) bool {
+	if f == nil {
+		return false
+	}
+	fi, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}
+
+func readYes(f *os.File) bool {
+	s := bufio.NewScanner(f)
+	if !s.Scan() {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(s.Text())) {
+	case "y", "yes":
+		return true
+	}
+	return false
+}
+
+// humanDur renders a positive duration compactly (e.g. "6d 23h", "18h 4m",
+// "45m", "30s").
+func humanDur(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	days := int(d.Hours()) / 24
+	hours := int(d.Hours()) % 24
+	mins := int(d.Minutes()) % 60
+	switch {
+	case days > 0:
+		return fmt.Sprintf("%dd %dh", days, hours)
+	case hours > 0:
+		return fmt.Sprintf("%dh %dm", hours, mins)
+	case mins > 0:
+		return fmt.Sprintf("%dm", mins)
+	default:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+}
+
+func formatExpiry(t time.Time) string {
+	if t.IsZero() {
+		return "(unknown)"
+	}
+	base := t.Local().Format("2006-01-02 15:04")
+	if d := time.Until(t); d > 0 {
+		return base + " (in " + humanDur(d) + ")"
+	}
+	return base + " (expired)"
+}
+
+func formatExpiryShort(t time.Time) string {
+	if t.IsZero() {
+		return "(unknown)"
+	}
+	base := t.Local().Format("2006-01-02")
+	if d := time.Until(t); d > 0 {
+		return base + " (" + humanDur(d) + ")"
+	}
+	return base + " (expired)"
+}

--- a/internal/runner/auth_test.go
+++ b/internal/runner/auth_test.go
@@ -1,0 +1,308 @@
+package runner
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/deploys-app/api"
+
+	"github.com/deploys-app/deploys/internal/auth"
+)
+
+func tempOut(t *testing.T) *os.File {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "out")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { f.Close() })
+	return f
+}
+
+func readOut(t *testing.T, f *os.File) string {
+	t.Helper()
+	b, err := os.ReadFile(f.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+// meGetServer returns an httptest server answering me.get with the arpc envelope.
+func meGetServer(t *testing.T, email string, ok bool) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !ok {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"ok":true,"result":{"email":"` + email + `","kyc":false}}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestIsAuthCommand(t *testing.T) {
+	for _, n := range []string{"login", "logout", "auth"} {
+		if !IsAuthCommand(n) {
+			t.Errorf("IsAuthCommand(%q) = false; want true", n)
+		}
+	}
+	for _, n := range []string{"me", "deployment", "version", "check-update", ""} {
+		if IsAuthCommand(n) {
+			t.Errorf("IsAuthCommand(%q) = true; want false", n)
+		}
+	}
+}
+
+func TestLoginGlue(t *testing.T) {
+	t.Setenv("DEPLOYS_CONFIG_DIR", t.TempDir())
+	me := meGetServer(t, "alice@example.com", true)
+	t.Setenv("DEPLOYS_ENDPOINT", me.URL)
+	t.Setenv("DEPLOYS_AUTH_ENDPOINT", "https://auth.deploys.app")
+
+	old := doLogin
+	doLogin = func(ctx context.Context, authBase, apiEndpoint string, opts auth.LoginOptions) (auth.Result, error) {
+		return auth.Result{Token: "deploys-api.glue", ExpiresIn: 7 * 24 * time.Hour}, nil
+	}
+	defer func() { doLogin = old }()
+
+	rn := Runner{Output: tempOut(t)}
+	if err := rn.login(); err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	out := readOut(t, rn.Output)
+	if !strings.Contains(out, "Logged in as alice@example.com") {
+		t.Errorf("login output missing identity:\n%s", out)
+	}
+
+	c, err := auth.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := auth.AccountKey(me.URL, "alice@example.com")
+	a, ok := c.Find(key)
+	if !ok {
+		t.Fatalf("account not persisted; store=%+v", c.Accounts)
+	}
+	if a.Token != "deploys-api.glue" {
+		t.Errorf("token = %q", a.Token)
+	}
+	if a.AuthEndpoint != "https://auth.deploys.app" {
+		t.Errorf("authEndpoint = %q", a.AuthEndpoint)
+	}
+	if k, ok := c.ActiveKey(me.URL); !ok || k != key {
+		t.Errorf("active not set to new account: %q ok=%v", k, ok)
+	}
+}
+
+func TestLoginMeGetFailurePersists(t *testing.T) {
+	t.Setenv("DEPLOYS_CONFIG_DIR", t.TempDir())
+	me := meGetServer(t, "", false) // 500 -> me.get fails
+	t.Setenv("DEPLOYS_ENDPOINT", me.URL)
+
+	old := doLogin
+	doLogin = func(ctx context.Context, authBase, apiEndpoint string, opts auth.LoginOptions) (auth.Result, error) {
+		return auth.Result{Token: "deploys-api.noident", ExpiresIn: 7 * 24 * time.Hour}, nil
+	}
+	defer func() { doLogin = old }()
+
+	rn := Runner{Output: tempOut(t)}
+	if err := rn.login(); err != nil {
+		t.Fatalf("login should still succeed when me.get fails: %v", err)
+	}
+	c, _ := auth.Load()
+	if len(c.Accounts) != 1 {
+		t.Fatalf("token not persisted under placeholder; accounts=%d", len(c.Accounts))
+	}
+	if c.Accounts[0].Token != "deploys-api.noident" {
+		t.Errorf("placeholder account token = %q", c.Accounts[0].Token)
+	}
+	if k, ok := c.ActiveKey(me.URL); !ok || k != c.Accounts[0].Key {
+		t.Errorf("placeholder account not active")
+	}
+}
+
+func TestAuthListAndStatus(t *testing.T) {
+	t.Setenv("DEPLOYS_CONFIG_DIR", t.TempDir())
+	// Ensure no env credential shadows the file source for status.
+	t.Setenv("DEPLOYS_TOKEN", "")
+	t.Setenv("DEPLOYS_AUTH_USER", "")
+	t.Setenv("DEPLOYS_AUTH_PASS", "")
+	ep := "https://api.deploys.app/"
+	t.Setenv("DEPLOYS_ENDPOINT", ep)
+
+	if err := auth.Mutate(func(cc *auth.Credentials) error {
+		cc.Upsert(auth.Account{Key: auth.AccountKey(ep, "alice@x"), Endpoint: ep, Email: "alice@x", Token: "t1", ExpiresAt: time.Now().Add(48 * time.Hour)})
+		cc.Upsert(auth.Account{Key: auth.AccountKey(ep, "bob@x"), Endpoint: ep, Email: "bob@x", Token: "t2", ExpiresAt: time.Now().Add(48 * time.Hour)})
+		cc.SetActive(ep, auth.AccountKey(ep, "alice@x"))
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// list
+	rn := Runner{Output: tempOut(t)}
+	if err := rn.authList(); err != nil {
+		t.Fatalf("authList: %v", err)
+	}
+	out := readOut(t, rn.Output)
+	for _, want := range []string{"ACTIVE", "ENDPOINT", "ACCOUNT", "EXPIRES", "alice@x", "bob@x"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("auth list missing %q:\n%s", want, out)
+		}
+	}
+
+	// status -> active account from the file
+	rn2 := Runner{Output: tempOut(t)}
+	if err := rn2.authStatus(); err != nil {
+		t.Fatalf("authStatus: %v", err)
+	}
+	st := readOut(t, rn2.Output)
+	if !strings.Contains(st, "credentials file") || !strings.Contains(st, "alice@x") {
+		t.Errorf("auth status missing active account:\n%s", st)
+	}
+}
+
+func TestAuthStatusEnvToken(t *testing.T) {
+	t.Setenv("DEPLOYS_CONFIG_DIR", t.TempDir())
+	t.Setenv("DEPLOYS_TOKEN", "deploys-api.env")
+	rn := Runner{Output: tempOut(t)}
+	if err := rn.authStatus(); err != nil {
+		t.Fatalf("authStatus: %v", err)
+	}
+	out := readOut(t, rn.Output)
+	if !strings.Contains(out, "DEPLOYS_TOKEN") {
+		t.Errorf("status should report env source:\n%s", out)
+	}
+}
+
+func TestAuthSwitch(t *testing.T) {
+	t.Setenv("DEPLOYS_CONFIG_DIR", t.TempDir())
+	ep := "https://api.deploys.app/"
+	t.Setenv("DEPLOYS_ENDPOINT", ep)
+	if err := auth.Mutate(func(cc *auth.Credentials) error {
+		cc.Upsert(auth.Account{Key: auth.AccountKey(ep, "alice@x"), Endpoint: ep, Email: "alice@x", Token: "t1", ExpiresAt: time.Now().Add(time.Hour)})
+		cc.Upsert(auth.Account{Key: auth.AccountKey(ep, "bob@x"), Endpoint: ep, Email: "bob@x", Token: "t2", ExpiresAt: time.Now().Add(time.Hour)})
+		cc.SetActive(ep, auth.AccountKey(ep, "alice@x"))
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	rn := Runner{Output: tempOut(t), Account: "bob@x"}
+	if err := rn.authSwitch(); err != nil {
+		t.Fatalf("authSwitch: %v", err)
+	}
+	c, _ := auth.Load()
+	if k, _ := c.ActiveKey(ep); k != auth.AccountKey(ep, "bob@x") {
+		t.Errorf("active not switched to bob: %q", k)
+	}
+}
+
+func TestAuthTokenPipeNoNewline(t *testing.T) {
+	t.Setenv("DEPLOYS_CONFIG_DIR", t.TempDir())
+	t.Setenv("DEPLOYS_TOKEN", "")
+	ep := "https://api.deploys.app/"
+	t.Setenv("DEPLOYS_ENDPOINT", ep)
+	if err := auth.Mutate(func(cc *auth.Credentials) error {
+		cc.Upsert(auth.Account{Key: auth.AccountKey(ep, "alice@x"), Endpoint: ep, Email: "alice@x", Token: "deploys-api.tok", ExpiresAt: time.Now().Add(time.Hour)})
+		cc.SetActive(ep, auth.AccountKey(ep, "alice@x"))
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Output is a regular file (not a TTY) -> prints without a trailing newline.
+	rn := Runner{Output: tempOut(t)}
+	if err := rn.authToken(); err != nil {
+		t.Fatalf("authToken: %v", err)
+	}
+	if got := readOut(t, rn.Output); got != "deploys-api.tok" {
+		t.Errorf("token output = %q; want exact token, no newline", got)
+	}
+}
+
+func TestLogoutRevokesAndRemoves(t *testing.T) {
+	t.Setenv("DEPLOYS_CONFIG_DIR", t.TempDir())
+	ep := "https://api.deploys.app/"
+	t.Setenv("DEPLOYS_ENDPOINT", ep)
+
+	var revoked bool
+	revokeSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/revoke" {
+			revoked = true
+		}
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer revokeSrv.Close()
+
+	if err := auth.Mutate(func(cc *auth.Credentials) error {
+		cc.Upsert(auth.Account{Key: auth.AccountKey(ep, "alice@x"), Endpoint: ep, AuthEndpoint: revokeSrv.URL, Email: "alice@x", Token: "deploys-api.tok", ExpiresAt: time.Now().Add(time.Hour)})
+		cc.SetActive(ep, auth.AccountKey(ep, "alice@x"))
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	rn := Runner{Output: tempOut(t)}
+	if err := rn.logout(); err != nil {
+		t.Fatalf("logout: %v", err)
+	}
+	if !revoked {
+		t.Error("logout did not call /revoke")
+	}
+	c, _ := auth.Load()
+	if len(c.Accounts) != 0 {
+		t.Errorf("account not removed after logout: %+v", c.Accounts)
+	}
+}
+
+func TestLogoutKeepsEntryOnRevokeFailure(t *testing.T) {
+	t.Setenv("DEPLOYS_CONFIG_DIR", t.TempDir())
+	ep := "https://api.deploys.app/"
+	t.Setenv("DEPLOYS_ENDPOINT", ep)
+
+	// An unreachable auth base makes revoke fail; the entry must be kept.
+	if err := auth.Mutate(func(cc *auth.Credentials) error {
+		cc.Upsert(auth.Account{Key: auth.AccountKey(ep, "alice@x"), Endpoint: ep, AuthEndpoint: "https://127.0.0.1:1", Email: "alice@x", Token: "deploys-api.tok", ExpiresAt: time.Now().Add(time.Hour)})
+		cc.SetActive(ep, auth.AccountKey(ep, "alice@x"))
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	rn := Runner{Output: tempOut(t)}
+	if err := rn.logout(); err == nil {
+		t.Fatal("logout should fail loudly when revoke fails")
+	}
+	c, _ := auth.Load()
+	if len(c.Accounts) != 1 {
+		t.Errorf("account should be kept when revoke fails; got %d", len(c.Accounts))
+	}
+}
+
+func TestLogoutNothingToDo(t *testing.T) {
+	t.Setenv("DEPLOYS_CONFIG_DIR", t.TempDir())
+	t.Setenv("DEPLOYS_ENDPOINT", "https://api.deploys.app/")
+	rn := Runner{Output: tempOut(t)}
+	if err := rn.logout(); err != nil {
+		t.Fatalf("logout with no accounts should be a no-op success: %v", err)
+	}
+	if out := readOut(t, rn.Output); !strings.Contains(out, "nothing to log out") {
+		t.Errorf("expected 'nothing to log out', got %q", out)
+	}
+}
+
+// guard: api.ErrForbidden must not be confused with the unauthorized sentinel by
+// callers; this documents the distinction the exit-code mapper relies on.
+func TestUnauthorizedSentinelDistinct(t *testing.T) {
+	if api.ErrUnauthorized == api.ErrForbidden {
+		t.Fatal("ErrUnauthorized and ErrForbidden must be distinct sentinels")
+	}
+}

--- a/internal/runner/help.go
+++ b/internal/runner/help.go
@@ -51,6 +51,18 @@ type subcommand struct {
 // listed — keep them in sync by hand.
 var commands = []command{
 	{
+		name:  "auth",
+		short: "log in and manage stored accounts",
+		subs: []subcommand{
+			{name: "login", short: "sign in via the browser and store the account"},
+			{name: "logout", args: "[-account email] [-all]", short: "revoke and remove a stored account"},
+			{name: "status", args: "[-endpoint url]", short: "show the credential in effect and its expiry"},
+			{name: "list", short: "list stored accounts grouped by endpoint"},
+			{name: "switch", args: "-account email [-endpoint url]", short: "change the active account for an endpoint"},
+			{name: "token", args: "[-endpoint url] [-force]", short: "print the resolved bearer token (for scripts)"},
+		},
+	},
+	{
 		name:  "me",
 		short: "identity and access for the current credential",
 		subs: []subcommand{
@@ -384,6 +396,10 @@ func PrintUsage(w io.Writer) {
 
 	fmt.Fprintln(w, "Commands:")
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	// login/logout are the primary verbs (aliases of auth login/logout); list
+	// them first, above the resource groups.
+	fmt.Fprintf(tw, "  %s\t%s\n", "login", "sign in via the browser (alias of auth login)")
+	fmt.Fprintf(tw, "  %s\t%s\n", "logout", "remove a stored account (alias of auth logout)")
 	for _, c := range commands {
 		name := c.name
 		if len(c.aliases) > 0 {
@@ -406,16 +422,35 @@ func PrintUsage(w io.Writer) {
 
 	fmt.Fprint(w, "\nFlags:\n")
 	fmt.Fprint(w, "  -output table|yaml|json   output mode (or the -oyaml, -ojson, -otable shorthands)\n")
+	fmt.Fprint(w, "  -account email            use a specific stored account for this command\n")
 
 	fmt.Fprint(w, "\nEnvironment:\n")
 	tw = tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	fmt.Fprint(tw, "  DEPLOYS_TOKEN\tbearer api token\n")
+	fmt.Fprint(tw, "  DEPLOYS_TOKEN\tbearer api token (overrides a stored login)\n")
 	fmt.Fprint(tw, "  DEPLOYS_AUTH_USER\tservice-account email (basic auth, with DEPLOYS_AUTH_PASS)\n")
 	fmt.Fprint(tw, "  DEPLOYS_AUTH_PASS\tservice-account key secret\n")
 	fmt.Fprint(tw, "  DEPLOYS_ENDPOINT\toverride the api endpoint\n")
+	fmt.Fprint(tw, "  DEPLOYS_ACCOUNT\tselect a stored account by email (same as -account)\n")
+	fmt.Fprint(tw, "  DEPLOYS_AUTH_ENDPOINT\toverride the auth (login) server\n")
+	fmt.Fprint(tw, "  DEPLOYS_CONFIG_DIR\toverride the config/credentials directory\n")
 	tw.Flush()
 
 	fmt.Fprint(w, "\nRun \"deploys <command> -h\" for a command's subcommands and flags.\n")
+}
+
+// writeLoginUsage writes the banner for the standalone `deploys login` verb.
+func writeLoginUsage(w io.Writer) {
+	fmt.Fprint(w, "login — sign in via the browser and store the account (alias of auth login)\n\n")
+	fmt.Fprint(w, "Usage:\n  deploys login [-endpoint url] [-no-browser] [-port n] [-timeout 3m]\n\n")
+	fmt.Fprint(w, "Opens a browser to authorize, then saves a credential under your config dir.\n")
+	fmt.Fprint(w, "On a remote/SSH host, use -no-browser and forward the printed callback port.\n")
+}
+
+// writeLogoutUsage writes the banner for the standalone `deploys logout` verb.
+func writeLogoutUsage(w io.Writer) {
+	fmt.Fprint(w, "logout — revoke and remove a stored account (alias of auth logout)\n\n")
+	fmt.Fprint(w, "Usage:\n  deploys logout [-account email] [-endpoint url] [-all] [-yes]\n\n")
+	fmt.Fprint(w, "With no flags, logs out the active account for the endpoint.\n")
 }
 
 // writeGroupUsage writes a group's help: its description, aliases, and the list

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -26,6 +26,11 @@ type Runner struct {
 	// Version is this binary's version, shown by check-update. Empty for an
 	// unknown/local build (reported as "dev").
 	Version string
+	// Account is the account selector (an email) pre-scanned from a global
+	// -account flag in main, or empty. The auth subcommands fall back to the
+	// DEPLOYS_ACCOUNT env var when this is empty; main threads the same value
+	// into the API client for normal commands.
+	Account string
 }
 
 func (rn Runner) output() *os.File {
@@ -104,6 +109,12 @@ func (rn Runner) Run(args ...string) error {
 	switch args[0] {
 	default:
 		return fmt.Errorf("invalid command: %q (run \"deploys help\")", args[0])
+	case "login":
+		return rn.login(args[1:]...)
+	case "logout":
+		return rn.logout(args[1:]...)
+	case "auth":
+		return rn.authGroup(args[1:]...)
 	case "me":
 		return rn.me(args[1:]...)
 	case "billing":

--- a/internal/runner/update.go
+++ b/internal/runner/update.go
@@ -32,6 +32,20 @@ func IsLocalCommand(name string) bool {
 	return false
 }
 
+// IsAuthCommand reports whether name is the login/logout/auth surface. These do
+// not use the pre-built rn.API (login establishes credentials; the auth
+// management subcommands read the store directly), so main must not build the
+// API client for them — building it could short-circuit with a "not logged in"
+// error before the user can even log in. Unlike IsLocalCommand, these may hit
+// the network (login/logout), so they are a separate predicate.
+func IsAuthCommand(name string) bool {
+	switch name {
+	case "login", "logout", "auth":
+		return true
+	}
+	return false
+}
+
 // versionInfo is the structured form of `deploys version` (for -ojson/-oyaml).
 type versionInfo struct {
 	Version string `json:"version" yaml:"version"`

--- a/main.go
+++ b/main.go
@@ -2,16 +2,19 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
 	"runtime/debug"
+	"strings"
 	"time"
 
 	"github.com/deploys-app/api"
 	"github.com/deploys-app/api/client"
 	"golang.org/x/oauth2/google"
 
+	"github.com/deploys-app/deploys/internal/auth"
 	"github.com/deploys-app/deploys/internal/runner"
 )
 
@@ -32,25 +35,113 @@ func main() {
 		return
 	}
 
+	// Pre-scan the global -account selector before the api client is built:
+	// per-subcommand flag.FlagSets parse too late to shape client construction.
+	// This runs after the bare/help fast-path above (which the empty-args case
+	// below also relies on), and extracts only the non-secret account email.
+	selector, args := extractAccountFlag(args)
+	if selector == "" {
+		selector = os.Getenv("DEPLOYS_ACCOUNT")
+	}
+	explicit := selector != ""
+	if len(args) == 0 {
+		// -account consumed the only token, e.g. `deploys -account x`.
+		runner.PrintUsage(os.Stdout)
+		return
+	}
+
 	rn := runner.Runner{
 		Output:  os.Stdout,
 		Version: resolveVersion(),
+		Account: selector,
 	}
 
-	// Local utility commands (check-update) run entirely client-side; skip
-	// building the api client so they never resolve Google credentials.
-	if !runner.IsLocalCommand(args[0]) {
-		rn.API = newAPIClient()
+	// Local utility commands (check-update/version) and the auth surface
+	// (login/logout/auth) run without the pre-built client: the former are
+	// client-less, the latter establish or read credentials themselves.
+	if !runner.IsLocalCommand(args[0]) && !runner.IsAuthCommand(args[0]) {
+		c, err := newAPIClient(selector, explicit)
+		if err != nil {
+			fail(err)
+		}
+		rn.API = c
 	}
 
-	err := rn.Run(args...)
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+	if err := rn.Run(args...); err != nil {
+		fail(err)
 	}
 }
 
-func newAPIClient() *client.Client {
+// fail prints an error and exits. An authentication-required error (no usable
+// credential, or an expired session reported by the api) maps to exit code 4 and
+// goes to stderr with a re-login hint; everything else keeps the legacy
+// stdout + exit 1 behavior so existing scripts are unaffected.
+func fail(err error) {
+	if exitCode(err) == 4 {
+		var are *auth.AuthRequiredError
+		if errors.As(err, &are) {
+			fmt.Fprintln(os.Stderr, "Error: "+err.Error())
+		} else {
+			fmt.Fprintln(os.Stderr, "Error: your deploys session has expired.")
+			fmt.Fprintln(os.Stderr, "Run 'deploys login' to sign in again.")
+		}
+		os.Exit(4)
+	}
+	fmt.Println(err)
+	os.Exit(1)
+}
+
+// exitCode classifies an error into a process exit code: 4 for an
+// authentication-required/expired error (a missing-or-expired stored login, or
+// the api's typed ErrUnauthorized), 1 otherwise. ErrForbidden (a valid token
+// lacking a permission) deliberately stays 1 — a permission denial is not a
+// reason to re-login.
+func exitCode(err error) int {
+	var are *auth.AuthRequiredError
+	if errors.As(err, &are) || errors.Is(err, api.ErrUnauthorized) {
+		return 4
+	}
+	return 1
+}
+
+// extractAccountFlag pulls a global -account/--account selector (in either
+// "-account v" or "-account=v" form) out of args and returns the value plus the
+// remaining args. It is a hand-rolled scan, not a flag.FlagSet, because the
+// selector must be known before the api client is built. It extracts only the
+// account email and must never be widened to read a token or any secret.
+func extractAccountFlag(args []string) (string, []string) {
+	var selector string
+	rest := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case a == "-account" || a == "--account":
+			if i+1 < len(args) {
+				selector = args[i+1]
+				i++
+			}
+		case strings.HasPrefix(a, "-account="):
+			selector = strings.TrimPrefix(a, "-account=")
+		case strings.HasPrefix(a, "--account="):
+			selector = strings.TrimPrefix(a, "--account=")
+		default:
+			rest = append(rest, a)
+		}
+	}
+	return selector, rest
+}
+
+// newAPIClient builds the api client, resolving credentials in order:
+//  1. DEPLOYS_AUTH_USER+DEPLOYS_AUTH_PASS  (service-account basic auth; CI)
+//  2. DEPLOYS_TOKEN                         (bearer; CI; empty is treated unset)
+//  3. a stored login for the endpoint       (from `deploys login`)
+//  4. Google Application Default Credentials (legacy fallback)
+//
+// Steps 1–2 are unchanged so CI is untouched. An explicitly-selected account
+// (-account/DEPLOYS_ACCOUNT) that does not resolve is a hard error, not an ADC
+// fallthrough; with nothing configured at all it returns an AuthRequiredError so
+// main can print a login hint instead of a bare "unauthorized" round-trip.
+func newAPIClient(selector string, explicit bool) (*client.Client, error) {
 	var (
 		token    = os.Getenv("DEPLOYS_TOKEN")
 		authUser = os.Getenv("DEPLOYS_AUTH_USER")
@@ -65,23 +156,54 @@ func newAPIClient() *client.Client {
 			Timeout: 15 * time.Second,
 		},
 	}
-	if apiClient.Auth == nil && authUser != "" && authPass != "" {
-		apiClient.Auth = func(r *http.Request) {
-			r.SetBasicAuth(authUser, authPass)
+
+	if authUser != "" && authPass != "" {
+		apiClient.Auth = func(r *http.Request) { r.SetBasicAuth(authUser, authPass) }
+		return apiClient, nil
+	}
+	if token != "" {
+		apiClient.Auth = bearerAuth(token)
+		return apiClient, nil
+	}
+
+	acct, expired, err := auth.Resolve(selector, endpoint, explicit)
+	if err != nil {
+		return nil, err
+	}
+	if acct != nil && acct.Token != "" {
+		if d := time.Until(acct.ExpiresAt); d > 0 && d < 24*time.Hour {
+			fmt.Fprintf(os.Stderr, "warning: your deploys session expires in %s — run 'deploys login' to sign in again\n", shortDur(d))
 		}
+		apiClient.Auth = bearerAuth(acct.Token)
+		return apiClient, nil
+	}
+	if expired && acct != nil {
+		fmt.Fprintf(os.Stderr, "warning: stored session for %s expired — run 'deploys login'\n", acct.Email)
 	}
 
-	if apiClient.Auth == nil && token == "" {
-		token, _ = getDefaultToken()
+	if adc, aerr := getDefaultToken(); aerr == nil && adc != "" {
+		apiClient.Auth = bearerAuth(adc)
+		return apiClient, nil
 	}
 
-	if apiClient.Auth == nil && token != "" {
-		apiClient.Auth = func(r *http.Request) {
-			r.Header.Set("Authorization", "Bearer "+token)
-		}
-	}
+	return nil, &auth.AuthRequiredError{Msg: "not logged in. Run 'deploys login' to sign in."}
+}
 
-	return apiClient
+func bearerAuth(token string) func(*http.Request) {
+	return func(r *http.Request) { r.Header.Set("Authorization", "Bearer "+token) }
+}
+
+// shortDur renders a positive duration compactly for the near-expiry warning.
+func shortDur(d time.Duration) string {
+	h := int(d.Hours())
+	switch {
+	case h >= 24:
+		return fmt.Sprintf("%dd %dh", h/24, h%24)
+	case h >= 1:
+		return fmt.Sprintf("%dh", h)
+	default:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	}
 }
 
 // resolveVersion reports this binary's version: the release value injected via

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/deploys-app/api"
+
+	"github.com/deploys-app/deploys/internal/auth"
+)
+
+func TestExtractAccountFlag(t *testing.T) {
+	cases := []struct {
+		name     string
+		in       []string
+		wantSel  string
+		wantRest []string
+	}{
+		{"none", []string{"project", "list"}, "", []string{"project", "list"}},
+		{"space form", []string{"-account", "a@x", "project", "list"}, "a@x", []string{"project", "list"}},
+		{"eq form", []string{"-account=a@x", "project", "list"}, "a@x", []string{"project", "list"}},
+		{"double dash", []string{"--account", "a@x", "me", "get"}, "a@x", []string{"me", "get"}},
+		{"double dash eq", []string{"--account=a@x", "me", "get"}, "a@x", []string{"me", "get"}},
+		{"after subcommand", []string{"deployment", "list", "-account", "a@x"}, "a@x", []string{"deployment", "list"}},
+		{"only flag", []string{"-account", "a@x"}, "a@x", []string{}},
+		{"last wins", []string{"-account", "a@x", "x", "-account=b@y"}, "b@y", []string{"x"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			sel, rest := extractAccountFlag(c.in)
+			if sel != c.wantSel {
+				t.Errorf("selector = %q; want %q", sel, c.wantSel)
+			}
+			if !reflect.DeepEqual(rest, c.wantRest) {
+				t.Errorf("rest = %#v; want %#v", rest, c.wantRest)
+			}
+		})
+	}
+}
+
+func TestExitCode(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"auth required", &auth.AuthRequiredError{Msg: "not logged in"}, 4},
+		{"wrapped auth required", fmt.Errorf("ctx: %w", &auth.AuthRequiredError{Msg: "x"}), 4},
+		{"unauthorized", api.ErrUnauthorized, 4},
+		{"wrapped unauthorized", fmt.Errorf("ctx: %w", api.ErrUnauthorized), 4},
+		{"forbidden stays 1", api.ErrForbidden, 1},
+		{"generic", fmt.Errorf("boom"), 1},
+	}
+	for _, c := range cases {
+		if got := exitCode(c.err); got != c.want {
+			t.Errorf("%s: exitCode = %d; want %d", c.name, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## What

Adds an interactive **`deploys login`** (browser-based OAuth) and **multiple-account** support to the CLI. Today auth is env-only; a human on a laptop has to hand-craft a token. This adds the `gh`/`gcloud`-style flow.

## How

- **Login flow** — OAuth 2.1 Authorization Code + PKCE (S256) + loopback redirect (RFC 8252) against `auth.deploys.app`, minting the same 7-day `user_tokens` bearer the web console uses. **No auth-server change**: it self-provisions a public client via Dynamic Client Registration (registered once with a port-less `http://127.0.0.1/callback`, cached per auth base) and `me.get` resolves the identity afterward.
- **Multi-account** — accounts persisted in a `0600` `credentials.json` under the config dir (`$DEPLOYS_CONFIG_DIR` → `$XDG_CONFIG_HOME/deploys` → OS config dir), keyed by `(endpoint, email)` with a **per-endpoint active pointer**. Atomic writes (`O_EXCL` temp + rename), parent-dir ownership/permission checks, an `O_EXCL` lock with stale-break.
- **Command surface** — top-level `login` / `logout` plus `deploys auth status|list|switch|token`; global `-account` selector + `DEPLOYS_ACCOUNT`.
- **Precedence (CI preserved)** — `DEPLOYS_AUTH_USER/PASS` → `DEPLOYS_TOKEN` → **stored active account (new)** → Google ADC. Service-account and `DEPLOYS_TOKEN` still win, so existing pipelines are untouched. An expired session or an explicit-but-missing `-account` exits **code 4** with a re-login hint (`api.ErrUnauthorized` reused; `ErrForbidden` stays exit 1).
- **No refresh grant exists**, so tokens just expire: a `<24h` warning, a clean exit-4 re-login message, and `auth status` showing remaining lifetime — never a silent renewal.

No changes to the `api` module / `client.Client` or to the auth server.

## Security

PKCE S256 (load-bearing for exchange confidentiality on shared hosts), `127.0.0.1`-only bind, random ephemeral port, constant-time `state` check, exact redirect binding, `Referrer-Policy: no-referrer` + no reflected input on the loopback pages, `https`-only non-loopback bases with issuer/same-origin metadata pinning, token never in argv (and `auth token` is TTY-guarded), logout revokes server-side and keeps the entry on revoke failure rather than orphaning a live token.

## Headless / SSH

The loopback flow needs a same-machine browser. On a remote host use `deploys login -no-browser` and forward the printed port (`ssh -L`), or the CI env vars. Code paste-back is deliberately **not** offered (it severs the PKCE verifier → phishing, and the bare-302 server has no copy-the-code page). A server-side device-code grant is the recommended future fix.

## Testing

`go build`, `go vet`, `go test ./...` and `go test -race ./...` all green. Tests cover: store round-trip + 0600 + corrupt/version handling + symlink refusal, resolver precedence (explicit vs implicit, per-endpoint independence, expiry), the full OAuth flow against an httptest server (S256, state validation, PKCE verify, client_id cache reuse), cross-origin metadata rejection, login/logout glue (incl. me.get-failure-still-persists and revoke-failure-keeps-entry), and exit-code classification.

Spec: `SPEC-cli-login.md` (workspace root). Ran `/scrutinize` on the change; fixed a loopback response-flush seam (browser could see a connection reset before the success page) and made `auth status` wording honest about the ADC fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)