### PR TITLE
feat(dropbox): add `dropbox upload-url` to mint signed upload URLs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/deploys-app/deploys
 go 1.26
 
 require (
-	github.com/deploys-app/api v0.0.0-20260623011239-7944629f3a01
+	github.com/deploys-app/api v0.0.0-20260624124707-f60cc534fe17
 	golang.org/x/mod v0.37.0
 	golang.org/x/oauth2 v0.14.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:W
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deploys-app/api v0.0.0-20260623011239-7944629f3a01 h1:kJ/caD13GAwdMXUSVWkIugGpmH5mFSDnL2yw+GrEKoQ=
-github.com/deploys-app/api v0.0.0-20260623011239-7944629f3a01/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
+github.com/deploys-app/api v0.0.0-20260624124707-f60cc534fe17 h1:GAn/6lKuql95SHw+++6FCsIhrXEYZ6A3JGH/bNfYZoE=
+github.com/deploys-app/api v0.0.0-20260624124707-f60cc534fe17/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/internal/runner/dropbox.go
+++ b/internal/runner/dropbox.go
@@ -71,6 +71,22 @@ func (rn Runner) dropbox(args ...string) error {
 			return err
 		}
 		resp, err = c.DropboxUpload(context.Background(), &opts)
+	case "upload-url":
+		var opts client.DropboxCreateUploadURLOptions
+		f.StringVar(&opts.Project, "project", "", "project sid")
+		f.StringVar(&opts.Filename, "filename", "", "filename recorded in the download")
+		f.StringVar(&opts.ContentType, "content-type", "", "Content-Type the upload must send (optional; enforced)")
+		f.Int64Var(&opts.MinSize, "min-size", 0, "minimum upload size in bytes (server floors at 1)")
+		f.Int64Var(&opts.MaxSize, "max-size", 0, "maximum upload size in bytes (server clamps to its cap, default 5 GiB)")
+		f.IntVar(&opts.TTLDays, "ttl", 0, "download lifetime in days, 1-7 (default 1)")
+		f.IntVar(&opts.Expires, "expires", 0, "upload-URL lifetime in seconds, 1-3600 (default 900)")
+		f.Parse(args[1:])
+
+		c, ok := rn.API.(*client.Client)
+		if !ok {
+			return fmt.Errorf("dropbox upload-url requires the default api client")
+		}
+		resp, err = c.DropboxCreateUploadURL(context.Background(), &opts)
 	}
 	if err != nil {
 		return err

--- a/internal/runner/help.go
+++ b/internal/runner/help.go
@@ -304,6 +304,7 @@ var commands = []command{
 			{name: "list", args: "[-after -before -limit]", short: "list dropbox files"},
 			{name: "metrics", args: "[-time-range 7d|30d|90d]", short: "show dropbox usage metrics"},
 			{name: "upload", args: "-file <path> [-filename -ttl]", short: "upload a file and print a short-lived download URL"},
+			{name: "upload-url", args: "-project <sid> [-filename -content-type -min-size -max-size -ttl -expires]", short: "mint a signed upload URL to hand off (recipient PUTs the file, no token needed)"},
 		},
 	},
 	{


### PR DESCRIPTION
## What

The dropbox service now mints **credential-free, time-limited upload URLs** (deploys-app/dropbox#24, api PR #114). This adds `deploys dropbox upload-url`:

```bash
deploys dropbox upload-url --project acme --filename build.tar.gz \
  --content-type application/gzip --max-size 104857600 --expires 900
```

It calls the new `client.DropboxCreateUploadURL` helper and prints the `uploadUrl` to hand off, the eventual `downloadUrl`, and the size/expiry limits. The recipient `PUT`s the file straight to dropbox — **no deploys.app token needed** (the URL is the capability).

Flags: `-project`, `-filename`, `-content-type`, `-min-size`, `-max-size`, `-ttl`, `-expires`. Sits alongside the existing `dropbox upload` / `list` / `metrics`.

## Dependency

Re-pins `github.com/deploys-app/api` to the commit adding `DropboxCreateUploadURL` (api PR #114, `3e859dd`). **Re-pin to `api/main` after #114 merges** (routine).

Build + `go test ./...` green locally (repo has no PR CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYMGjvqWELm2ctgKamiMSS