### PR TITLE
go.mod: re-pin api for new managed sidecars (AlloyDB + cloudSqlProxy IAM)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/deploys-app/deploys
 go 1.26
 
 require (
-	github.com/deploys-app/api v0.0.0-20260624124707-f60cc534fe17
+	github.com/deploys-app/api v0.0.0-20260624230758-1c5fa23612ff
 	golang.org/x/mod v0.37.0
 	golang.org/x/oauth2 v0.14.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:W
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deploys-app/api v0.0.0-20260624124707-f60cc534fe17 h1:GAn/6lKuql95SHw+++6FCsIhrXEYZ6A3JGH/bNfYZoE=
-github.com/deploys-app/api v0.0.0-20260624124707-f60cc534fe17/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
+github.com/deploys-app/api v0.0.0-20260624230758-1c5fa23612ff h1:ph9NYVU5AOgABifC+6+CfRxenrEXtz+xKIuku1MUkVk=
+github.com/deploys-app/api v0.0.0-20260624230758-1c5fa23612ff/go.mod h1:X70UJs5awlRV4Cmn0FPJAgEbn4N933K8YgSKc1y9aD8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=


### PR DESCRIPTION
Re-pins `github.com/deploys-app/api` to `1c5fa23` (api#115 AlloyDB sidecar variant, api#116 `cloudSqlProxy` `autoIamAuthn`/`privateIp` flags + port guard).

Dependency bump only — the CLI marshals a deployment spec into `api.DeploymentDeploy`, so the new `sidecars` fields become usable from a deploy spec with no CLI code change. `go build ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)